### PR TITLE
CASMUSER-2845: Fix goss test that verifies UAN discovery in SLS and HSM

### DIFF
--- a/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
+++ b/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
@@ -66,11 +66,7 @@ Install and configure the COS product before performing this procedure.
     Count: 15, Failed: 0, Skipped: 0
     ```
 
-11. Run the `./tests/goss/scripts/uan\_preflight\_same\_in\_sls\_and\_hsm.py` script if the previous step reports an error for the `uans_same_in_sls_and_hsm` Goss test. Address any errors that are reported.
-
-    This script must be run rerun manually because this test produces erroneous failures otherwise.
-
-12. Manually verify the UAN software prerequisites.
+11. Manually verify the UAN software prerequisites.
 
     1. Verify that the cray CLI tool, manifestgen, and loftsman are installed.
 

--- a/tests/goss/scripts/uan_preflight_same_in_sls_and_hsm.py
+++ b/tests/goss/scripts/uan_preflight_same_in_sls_and_hsm.py
@@ -31,6 +31,10 @@ def main():
             print("ERROR: System Layout Service (SLS) contains UAN nodes the Hardware State Manager (HSM) does not.")
             print("Nodes: ", in_sls_not_hsm)
         sys.exit(1)
+    else:
+        print("PASS: System Layout Service (SLS) and Hardware State Manager (HSM) contain the same UAN nodes.")
+        print("Nodes: ", sls_known_uans)
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/tests/goss/tests/goss-software-prereqs.yaml
+++ b/tests/goss/tests/goss-software-prereqs.yaml
@@ -104,11 +104,11 @@ command:
   uans_same_in_sls_and_hsm:
     title: Ensure SLS and HSM agree on UAN node membership
     meta:
-      desc: Have the User Access Node (UAN) nodes listed in System Layout Service (SLS) been detected by the Hardware State Manager (HSM); If this test fails, run {{.Env.GOSS_BASE}}/scripts/uan_preflight_same_in_sls_and_hsm.py
+      desc: Have the User Access Node (UAN) nodes listed in System Layout Service (SLS) been detected by the Hardware State Manager (HSM).
       sev: 0
-    exec: "/usr/bin/env python3 {{.Env.GOSS_BASE}}/scripts/uan_preflight_check.py"
+    exec: "/usr/bin/env python3 {{.Env.GOSS_BASE}}/scripts/uan_preflight_same_in_sls_and_hsm.py"
     stdout:
-    - "!ERROR"
+    - "PASS"
     exit-status: 0
     timeout: 10000
     skip: false


### PR DESCRIPTION
This PR fixes the goss verification test for UAN discovery in SLS and HSM.

It also updates the test script to provide confirmation output on a passing run.