### PR TITLE
Build uan-product-stream in github for UAN 2.1.X releases

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -17,23 +17,22 @@ pipeline {
         PRODUCT = "uan"
         RELEASE_VERSION = sh(returnStdout: true, script: "./version.sh").trim()
         GIT_TAG = sh(returnStdout: true, script: "git rev-parse --short HEAD").trim()
-        BRANCH_BUILD = branchBuild()
-        SNYK_TOKEN = credentials('snyk-token')
+        IS_STABLE = getBuildIsStable()
     }
 
     stages {
-        stage("Check version") {
-            if("${env.RELEASE_VERSION}" == "null" || "${env.RELEASE_VERSION}" == "") {
-                error "Environment variable RELEASE_VERSION not set."
-            } else {
-                echo "Version: ${env.RELEASE_VERSION}"
+        stage("Build") {
+            steps {
+                sh "make"
             }
         }
 
-        stage("Build") {
-        }
-
         stage("Publish") {
+            steps {
+                script {
+                    publishUan(isStable: env.IS_STABLE, version: env.RELEASE_VERSION, pattern: "${WORKSPACE}/dist/uan-"+env.RELEASE_VERSION+".tar.gz")
+                }
+            }
         }
     }
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,70 +1,46 @@
 // Jenkinsfile to push uan-product-stream repo to github
 // Copyright 2021 Hewlett Packard Enterprise Development LP
- 
-@Library('dst-shared@master') _
+@Library('csm-shared-library') _
 
 pipeline {
     agent {
-        kubernetes {
-            label "uan-product-stream-github-push"
-            containerTemplate {
-                name "uan-product-stream-github-push-cont"
-                image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-alpine3_build_environment:latest"
-                ttyEnabled true
-                command "cat"
-            }
-        }
+        label "metal-gcp-builder"
     }
 
-    // Configuration options applicable to the entire job
     options {
-        // This build should not take long, fail the build if it appears stuck
-        timeout(time: 10, unit: 'MINUTES')
-
-        // Don't fill up the build server with unnecessary cruft
-        buildDiscarder(logRotator(numToKeepStr: '5'))
-
-        // Add timestamps and color to console output, cuz pretty
+        buildDiscarder(logRotator(numToKeepStr: "10"))
         timestamps()
     }
 
     environment {
-        // Set environment variables here
+        RELEASE_NAME = "uan"
+        PRODUCT = "uan"
+        RELEASE_VERSION = sh(returnStdout: true, script: "./version.sh").trim()
         GIT_TAG = sh(returnStdout: true, script: "git rev-parse --short HEAD").trim()
+        BRANCH_BUILD = branchBuild()
+        SNYK_TOKEN = credentials('snyk-token')
     }
 
     stages {
-        stage('Push to github') {
-            when { allOf {
-                expression { BRANCH_NAME ==~ /(bugfix\/.*|feature\/.*|hotfix\/.*|main|master|release\/.*)/ }
-            }}
-            steps {
-                container('uan-product-stream-github-push-cont') {
-                    sh """
-                        apk add --no-cache bash curl jq git openssl
-                    """
-                    script {
-                        pushToGithub(
-                            githubRepo: "Cray-HPE/uan-product-stream",
-                            pemSecretId: "githubapp-stash-sync",
-                            githubAppId: "91129",
-                            githubAppInstallationId: "13313749"
-                        )
-                    }
-                }
+        stage("Check version") {
+            if("${env.RELEASE_VERSION}" == "null" || "${env.RELEASE_VERSION}" == "") {
+                error "Environment variable RELEASE_VERSION not set."
+            } else {
+                echo "Version: ${env.RELEASE_VERSION}"
             }
+        }
+
+        stage("Build") {
+        }
+
+        stage("Publish") {
         }
     }
 
-    post('Post-build steps') {
-        failure {
-            emailext (
-                subject: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-                body: """<p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':</p>
-                <p>Check console output at &QUOT;<a href='${env.BUILD_URL}'>${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>&QUOT;</p>""",
-                recipientProviders: [[$class: 'CulpritsRecipientProvider'], [$class: 'RequesterRecipientProvider']]
-            )
+    post {
+        always {
+            // Own files so jenkins can clean them up later
+            postChownFiles()
         }
-
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+BUILD_DATE ?= $(shell date +'%Y%m%d%H%M%S')
+RELEASE_VERSION ?= $(shell ./version.sh)-local
+GIT_TAG ?= $(shell git rev-parse --short HEAD)
+
+all : generate_release
+
+generate_release:
+	./release.sh

--- a/vendor/git@stash.us.cray.com/7999/shastarelm/release/lib/release.sh
+++ b/vendor/git@stash.us.cray.com/7999/shastarelm/release/lib/release.sh
@@ -4,7 +4,7 @@
 
 : "${PACKAGING_TOOLS_IMAGE:=arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.7.0}"
 : "${RPM_TOOLS_IMAGE:=arti.dev.cray.com/internal-docker-stable-local/rpm-tools:1.0.0}"
-: "${SKOPEO_IMAGE:=quay.io/skopeo/stable:latest}"
+: "${SKOPEO_IMAGE:=quay.io/skopeo/stable:v1.4.1}"
 : "${CRAY_NEXUS_SETUP_IMAGE:=arti.dev.cray.com/csm-docker-stable-local/cray-nexus-setup:0.5.2}"
 
 # Prefer to use docker, but for environments with podman

--- a/vendor/stash.us.cray.com/scm/shastarelm/release/lib/release.sh
+++ b/vendor/stash.us.cray.com/scm/shastarelm/release/lib/release.sh
@@ -4,7 +4,7 @@
 
 : "${PACKAGING_TOOLS_IMAGE:=arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.9.0}"
 : "${RPM_TOOLS_IMAGE:=arti.dev.cray.com/internal-docker-stable-local/rpm-tools:1.0.0}"
-: "${SKOPEO_IMAGE:=quay.io/skopeo/stable:latest}"
+: "${SKOPEO_IMAGE:=quay.io/skopeo/stable:v1.4.1}"
 : "${CRAY_NEXUS_SETUP_IMAGE:=arti.dev.cray.com/csm-docker-stable-local/cray-nexus-setup:0.5.2}"
 
 # Prefer to use docker, but for environments with podman


### PR DESCRIPTION
## Summary and Scope

Add changes needed to get `uan-product-stream` building in github

## Issues and Related PRs

* Unblocks future changes for 2.1.X releases to occur in github

## Testing

Installed a 2.1.8-alpha.3 on baldar

### Test description:

The 2.1.8-alpha.3 installed on baldar

## Risks and Mitigations

The manifests haven't changed yet so this is building a new release with the artifacts used
in 2.1.7 so the risk is low.

## Pull Request Checklist

- [ n/a ] Version number(s) incremented, if applicable
- [ X ] Copyrights updated
- [ X ] License file intact
- [ X ] Target branch correct
- [ X ] CHANGELOG.md updated
- [ X ] Testing is appropriate and complete, if applicable
- [ n/a ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

