### PR TITLE
UAN 2.1.8 Release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.8] - 2021-11-16
+- CASMUSER-2912: Pin versions correctly for CFS plays from other products
+- Use UAN and CSM artifacts from algol60
+
 ## [2.1.7] - 2021-10-28
 - CASMUSER-2624: Add kdump support for HPE DL UAN nodes
 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,9 +1,13 @@
-arti.dev.cray.com:
+artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
-    uan-docker-stable-local/cray-uan-config:
-    - 0.2.37
-    uan-docker-stable-local/cray-uan-image-recipe:
-    - 0.2.37
-    csm-docker-stable-local/cray-product-catalog-update:
-    - 0.4.2
+    cray-uan-config:
+    - 0.2.38
+    cray-uan-image-recipe:
+    - 0.2.38
+
+artifactory.algol60.net/csm-docker/stable:
+  tls-verify: true
+  images:
+    cray-product-catalog-update:
+    - 0.4.3

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -1,4 +1,4 @@
-https://arti.dev.cray.com/artifactory/shasta-helm-stable-virtual/:
+https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.1.42
+    - 1.1.43

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -4,25 +4,25 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.1.42
+    version: 1.1.43
     namespace: services
     values:
       cray-import-config:
         catalog:
           image:
-            tag: 0.4.2
+            tag: 0.4.3
         config_image:
           name: cray-uan-config
-          tag: 0.2.37
+          tag: 0.2.38
         import_job:
           CF_IMPORT_PRODUCT_VERSION: "@product_version@"
       cray-import-kiwi-recipe-image:
         catalog:
           image:
-            tag: 0.4.2
+            tag: 0.4.3
         import_image:
           name: cray-uan-image-recipe
-          tag: 0.2.37
+          tag: 0.2.38
         import_job:
           name: "uan-image-recipe-import-@product_version@"
           PRODUCT_VERSION: "@product_version@"

--- a/nexus-repositories-online.yaml.tmpl
+++ b/nexus-repositories-online.yaml.tmpl
@@ -5,7 +5,7 @@ format: raw
 storage:
   blobStoreName: @name@
 proxy:
-  remoteUrl: @bloblet_url@/rpms/cray-sles15-sp2-ncn
+  remoteUrl: @bloblet_url@/sles-15sp2
 
 ---
 name: @name@-2.1-sle-15sp2

--- a/release.sh
+++ b/release.sh
@@ -78,14 +78,12 @@ function sync_repo_content {
     skopeo-sync "${ROOTDIR}/docker/index.yaml" "${BUILDDIR}/docker"
 
     # Modify how docker images will be imported so helm charts will work without changes
-    mkdir "${BUILDDIR}/docker/arti.dev.cray.com/cray"
-    mv ${BUILDDIR}/docker/arti.dev.cray.com/csm-docker-stable-local/* "${BUILDDIR}/docker/arti.dev.cray.com/cray"
-    mv ${BUILDDIR}/docker/arti.dev.cray.com/uan-docker-stable-local/* "${BUILDDIR}/docker/arti.dev.cray.com/cray"
-    rmdir "${BUILDDIR}/docker/arti.dev.cray.com/csm-docker-stable-local"
-    rmdir "${BUILDDIR}/docker/arti.dev.cray.com/uan-docker-stable-local"
+    mkdir -p "${BUILDDIR}/docker/arti.dev.cray.com/cray"
+    mv ${BUILDDIR}/docker/artifactory.algol60.net/*-docker/*stable/* "${BUILDDIR}/docker/arti.dev.cray.com/cray"
+    rm -r "${BUILDDIR}/docker/artifactory.algol60.net"
 
     # sync uan repos from bloblet
-    reposync "${BLOBLET_URL}/rpms/cray-sles15-sp2-ncn/" "${BUILDDIR}/rpms/cray-sles15-sp2-ncn/"
+    reposync "${BLOBLET_URL}/sle-15sp2" "${BUILDDIR}/rpms/sle-15sp2"
 }
 
 function sync_install_content {

--- a/vars.sh
+++ b/vars.sh
@@ -9,17 +9,4 @@ MAJOR=`./vendor/semver get major ${VERSION}`
 MINOR=`./vendor/semver get minor ${VERSION}`
 PATCH=`./vendor/semver get patch ${VERSION}`
 
-# For building and installing a master distribution, use 'master' here.
-#UAN_RELEASE_VERSION=master
-#UAN_RELEASE_PREFIX=dev
-
-# For building and installing a release distribution, use the DST Shasta release
-# here and comment above.
-# Note that "uan-2.1-bloblet" is used because the uan.blobets file is in a 
-# branch "release/uan-2.1-bloblet" in this repo. This will get better 
-# when arti.dev.cray.com is used for rpms
-UAN_RELEASE_VERSION=${NAME}-2.1-bloblet
-UAN_RELEASE_PREFIX=release
-
-BLOBLET_URL="http://dst.us.cray.com/dstrepo/bloblets/${NAME}/${UAN_RELEASE_PREFIX}/${UAN_RELEASE_VERSION}"
-CAR_URL="http://car.dev.cray.com/artifactory/${NAME}/SCMS/sle15_sp2_ncn"
+BLOBLET_URL="https://artifactory.algol60.net/artifactory/uan-rpms/hpe/stable"


### PR DESCRIPTION
## Summary and Scope

Create the v2.1.8 release with the following fixes:
- CASMUSER-2912: Pin versions correctly for CFS plays from other products
- Use UAN and CSM artifacts from algol60

## Issues and Related PRs

* Resolves CASMUSER-2912

## Testing

baldar and odin. Installed new product stream and generated images.

uan04 on odin was booted with the 2.1.8 release

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Ran through a CFS merge and image build and customization
- Were continuous integration tests run? If not, why? UAN was booted with all other product layers like Slurm, PE, etc...
- Was upgrade tested? If not, why? CFS was merged with previous CFS changes
- Was downgrade tested? If not, why? Downgrading not needed, previous UAN product is still available
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There is risk in generating this release from github, but an install of the 2.1.8 release showed
no issues on odin and baldar.

## Pull Request Checklist

- [ X ] Version number(s) incremented, if applicable
- [ X ] Copyrights updated
- [ X ] License file intact
- [ X ] Target branch correct
- [ X ] CHANGELOG.md updated
- [ X ] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable