### PR TITLE
CASMTRIAGE-1931: Allow more time for a goss check to complete

### DIFF
--- a/tests/goss/tests/goss-software-prereqs.yaml
+++ b/tests/goss/tests/goss-software-prereqs.yaml
@@ -77,7 +77,7 @@ command:
     - "deployed cray-product-catalog"
     - "deployed gitea"
     exit-status: 0
-    timeout: 1000
+    timeout: 10000
     skip: false
   cos_installed:
     title: COS is installed


### PR DESCRIPTION
## Summary and Scope

Allow more time for a goss check to complete.

## Issues and Related PRs

* Resolves CASMTRIAGE-2812

## Testing

Tested on odin

### Test description:

Reran the goss check and it was able to complete. The previous timeout was too small

## Risks and Mitigations

No

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

