### PR TITLE
CASMUSER-2920: Provide uan_disable_gpg_check support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- CASMUSER-2920: Provide uan_disable_gpg_check support
 - CASMTRIAGE-2721: Update copyrights and license headers
 - CASMUSER-2907: Remove online install support and doc references
 - CASM-2594: Update reference to CSM repo to use algol60

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 0.3.2
+    - 0.3.3
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.2.2
+    - 1.2.3

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.2.2
+    version: 1.2.3
     namespace: services
     values:
       cray-import-config:
@@ -36,6 +36,6 @@ spec:
             tag: 1.2.62
         config_image:
           name: cray-uan-config
-          tag: 0.3.2
+          tag: 0.3.3
         import_job:
           CF_IMPORT_PRODUCT_VERSION: "@product_version@"


### PR DESCRIPTION
## Summary and Scope

This PR provides support for a uan_disable_gpg_check switch to control GPG key checking on repos and packages being install on UAN images by the uan_packages CFS role.

## Issues and Related PRs

* Resolves CASMUSER-2920

## Testing

### Tested on:

  * `baldar`
  
### Test description:

Image customization was tested on baldar with and without the csm.gpg_keys role being available with and without the uan_disable_gpg_check variable set.  Expected results, both pass and failures, were observed.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [ X] Version number(s) incremented, if applicable
- [ X] Copyrights updated
- [X ] License file intact
- [ X] Target branch correct
- [X ] CHANGELOG.md updated
- [X ] Testing is appropriate and complete, if applicable
- [N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

