### PR TITLE
CASMUSER-2931: Use both Application and Application_UAN in the docs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Specify Application as a target group in CFS documentation
 
 ## [2.3.0] - 2021-12-15
 - CASMUSER-2926: Add loki fixes for COS 2.2 and CSM artifacts

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -252,6 +252,7 @@ Replace PRODUCT\_VERSION and CRAY\_EX\_HOSTNAME in the example commands in this 
     ncn-m001# cray cfs sessions create --name uan-config-PRODUCT_VERSION \
                       --configuration-name uan-config-PRODUCT_VERSION \
                       --target-definition image \
+                      --target-group Application IMAGE_ID\
                       --target-group Application_UAN IMAGE_ID\
                       --format json
     ```


### PR DESCRIPTION
## Summary and Scope

Documentation change to specify both Application and Application_UAN when running CFS.

Slingshot host software uses Application and not Application_UAN, so to add the SHS plays,
this ansible host must also be specified.

## Issues and Related PRs

* Resolves CASMUSER-2931

## Testing

### Tested on:

  * `loki`
  
### Test description:

This is how images were built on loki and is typically how admins have been running CFS already.

## Risks and Mitigations

No


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

