### PR TITLE
CASMUSER-2977: Change docs to leverage sat bootprep

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Change documentation to use sat bootprep
 - Updates to vendor directory for generating and installing releases
 
 ## [2.3.2] - 2022-03-01

--- a/docs/portal/developer-portal/upgrade/Merge_UAN_Configuration_Data.md
+++ b/docs/portal/developer-portal/upgrade/Merge_UAN_Configuration_Data.md
@@ -126,13 +126,6 @@ In this procedure, an upgrade from UAN 2.0.0 to UAN 2.3.1 is being performed. Ad
        --file uan-config-2.3.1.json
        ```
 
-    5. Tell CFS to apply the new configuration to UANs by repeating the following command for each UAN. Replace `UAN_XNAME` in the command below with the name of a different UAN each time the command is run.
-
-        ```bash
-        ncn-m001# cray cfs components update --desired-config uan-config-2.0.1 \
-        --enabled true --format json UAN_XNAME
-        ```
-
 10. Finish the typescript file started at the beginning of this procedure.
 
     ```bash

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -16,11 +16,12 @@ When an upgrade is being performed, please review the notable changes for **all*
   * `uan_disable_gpg_check: yes` must be set if CSM is earlier than 1.2
   * `uan_disable_gpg_check: no` should be set if CSM is 1.2 or greater
 
-## UAN 2.3.2
+## UAN 2.4.0
 
-* UAN 2.3.2 adds support for a Bifurcated Customer Access Network \(BiCAN\) and the ability to specify a default route other than the CAN or CHN when they are selected.  
+* UAN 2.4.0 adds support for a Bifurcated Customer Access Network \(BiCAN\) and the ability to specify a default route other than the CAN or CHN when they are selected.  
   * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customers user network.  By default, a direct connection is selected as it was in previous releases.  The choice of `CAN` or `CHN` must match the overall system implementation.
     * `uan_user_access_cfg` selects the customer access network implementation to use and replaces `uan_can_setup`.  Valid values are `CAN`, `CHN`, or `DIRECT`.  Default is `DIRECT`.
     * `uan_can_setup` is now deprecated.  If present and true, it resolves to `uan_user_access_cfg: CAN`.
   * Application nodes may now set a default route other than the CAN or CHN default route when CAN or CHN are selected.
     * `uan_customer_default_route: true` will allow a customer defined default route to be set using the `customer_uan_routes` structure when `uan_user_access_cfg` is set to `CAN` or `CHN`.
+* `sat bootprep` is now used in the documentation to streamline the IMS, CFS, and BOS commands to create and customize images and creating sessiontemplates.

--- a/docs/portal/developer-portal/upgrade/Upgrades.md
+++ b/docs/portal/developer-portal/upgrade/Upgrades.md
@@ -1,6 +1,6 @@
 # Upgrades
 
-Performing an upgrade of UAN from one version to the next follows the same general process as a fresh install. Some considerations may need to be made  when merging the existing CFS configuration with the latest CFS configuration provided by the release.
+Performing an upgrade of UAN from one version to the next follows the same general process as a fresh install. Some considerations may need to be made when merging the existing CFS configuration with the latest CFS configuration provided by the release.
 
 The overall workflow for completing a UAN upgrade involves:
 
@@ -10,11 +10,4 @@ The overall workflow for completing a UAN upgrade involves:
 
 3. [Merge UAN CFS Configuration Data](Merge_UAN_Configuration_Data.md)
 
-4. [Recreate UAN images from an IMS recipe](../operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md)
-
-5. [Customize UAN images and reboot](../operations/Create_UAN_Boot_Images.md)
-* Run CFS Image Customization on the new UAN image
-   
-* Update the BOS session template
-   
-* Reboot the UANs
+4. [Create UAN images and reboot](../operations/Create_UAN_Boot_Images.md)


### PR DESCRIPTION
## Summary and Scope

Change UAN documentation to use sat bootprep for creating CFS, IMS, and BOS
artifacts.

## Issues and Related PRs

* Resolves CASMUSER-2977

## Testing

Tested on `hela`

### Test description:

I followed the new procedure to generate UAN artifacts

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N (doc only)
- Were continuous integration tests run? If not, why? N (doc only)
- Was upgrade tested? If not, why? N (doc only)
- Was downgrade tested? If not, why? N (doc only)
- Were new tests (or test issues/Jiras) created for this change? N (doc only)

## Risks and Mitigations

This substantially reduces the steps and reduces risk.

## Pull Request Checklist

- [] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

