### PR TITLE
Tpccms 230 main

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Updates to vendor directory for generating and installing releases
 
-## [2.3.2] - 2022-02-24
-- Add support for BiCAN (CHN) and customer defined default route with CHN/CAN
+## [2.3.2] - 2022-03-01
+- Updates to CFS plays for GPU fixes
+- Updates to CFS plays for DVS/Lustre/configure_fs fixes
+- Enable publishing of docs to HPE Support Center
 
 ## [2.3.1] - 2022-02-15
 - Fix uan_packages to correctly check signatures

--- a/docs/portal/developer-portal/About_UAN_Administration.md
+++ b/docs/portal/developer-portal/About_UAN_Administration.md
@@ -1,0 +1,1 @@
+# About UAN Administration

--- a/docs/portal/developer-portal/Administrative_Tasks.md
+++ b/docs/portal/developer-portal/Administrative_Tasks.md
@@ -1,0 +1,1 @@
+# Administrative Tasks

--- a/docs/portal/developer-portal/Advanced_Administrative_Tasks.md
+++ b/docs/portal/developer-portal/Advanced_Administrative_Tasks.md
@@ -1,0 +1,1 @@
+# Advanced Administrative Tasks

--- a/docs/portal/developer-portal/Manage_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/Manage_UAN_Boot_Images.md
@@ -1,0 +1,1 @@
+# Manage UAN Boot Images

--- a/docs/portal/developer-portal/Reference.md
+++ b/docs/portal/developer-portal/Reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/docs/portal/developer-portal/Troubleshooting.md
+++ b/docs/portal/developer-portal/Troubleshooting.md
@@ -1,0 +1,1 @@
+# Troubleshooting

--- a/docs/portal/developer-portal/admin_publication.json
+++ b/docs/portal/developer-portal/admin_publication.json
@@ -8,6 +8,7 @@
 "source_system_id": "GUID-9999999999-ABCD-0000-9999-9999999999",
 "source_system_version": "1",
 "lifecycle": "DRAFT",
+"products": ["1013083813"],
 "col_id": "crs8033",
 "full_title": "HPE Cray User Access Node (UAN) Software Administration Guide (S-8033)",
 "description": "This publication describes how to manage and troubleshoot User Access Nodes (UANs).",

--- a/docs/portal/developer-portal/admin_publication.json
+++ b/docs/portal/developer-portal/admin_publication.json
@@ -1,0 +1,23 @@
+{
+"doc_id": "crs8033_1en_us",
+"content_version": "1",
+"document_part_number": "S-8033",
+"content_type": "htmlzip",
+"content_class": "html-default",
+"source_system": "SDL",
+"source_system_id": "GUID-9999999999-ABCD-0000-9999-9999999999",
+"source_system_version": "1",
+"lifecycle": "DRAFT",
+"col_id": "crs8033",
+"full_title": "HPE Cray User Access Node (UAN) Software Administration Guide (S-8033)",
+"description": "This publication describes how to manage and troubleshoot User Access Nodes (UANs).",
+"creation_date": "2022-03-29T12:00:00",
+"content_update_date": "2022-03-29T13:00:00",
+"language_code": "en_US",
+"object_name": "crs8033_1en_us",
+"file_name": "crs8033_1en_us.zip",
+"submitter": "darrenn.jackson@hpe.com",
+"company_info": "HPE-green",
+"customer_available_date": "",
+"content_org": "CMG708"
+}

--- a/docs/portal/developer-portal/advanced/Customizing_UAN_Images_Manually.md
+++ b/docs/portal/developer-portal/advanced/Customizing_UAN_Images_Manually.md
@@ -1,4 +1,4 @@
-## Customizing UAN Images Manually
+# Customizing UAN Images Manually
 
 1. Query IMS for the UAN Image you want to customize.
 

--- a/docs/portal/developer-portal/build.sh
+++ b/docs/portal/developer-portal/build.sh
@@ -1,0 +1,11 @@
+rm -rf build/;
+mkdir build/;
+export DOCS_BUILD_DIR=$PWD;
+echo "Building UAN Install Guide";
+dita -i uan_install.ditamap -o build/install -f HPEscHtml5 && cp install_publication.json build/install/publication.json && cd build/install/ && zip -r crs8032_1en_us.zip ./;
+cd $DOCS_BUILD_DIR;
+echo "Building UAN Admin Guide";
+dita -i uan_admin.ditamap -o build/admin -f HPEscHtml5 && cp admin_publication.json build/admin/publication.json && cd build/admin/ && zip -r crs8033_1en_us.zip ./;
+
+
+

--- a/docs/portal/developer-portal/direct_publish_hpesc.sh
+++ b/docs/portal/developer-portal/direct_publish_hpesc.sh
@@ -1,0 +1,2 @@
+curl -v -X POST -H "X-Communication-Id: $X_COMMUNICATION_ID" -H "X-Auth-Token: $X_AUTH_TOKEN" -H "Content-Type: multipart/form-data" -F "file=@build/install/crs8032_1en_us.zip" 'https://api.support.hpe.com/document-loader/v1/pushcontent/';
+curl -v -X POST -H "X-Communication-Id: $X_COMMUNICATION_ID" -H "X-Auth-Token: $X_AUTH_TOKEN" -H "Content-Type: multipart/form-data" -F "file=@build/admin/crs8033_1en_us.zip" 'https://api.support.hpe.com/document-loader/v1/pushcontent/'

--- a/docs/portal/developer-portal/direct_publish_itg.sh
+++ b/docs/portal/developer-portal/direct_publish_itg.sh
@@ -1,0 +1,2 @@
+curl -v -X POST -H "X-Communication-Id: $X_COMMUNICATION_ID_ITG" -H "X-Auth-Token: $X_AUTH_TOKEN_ITG" -H "Content-Type: multipart/form-data" -F "file=@build/install/crs8032_1en_us.zip" 'https://api-itg.support.hpe.com/document-loader/v1/pushcontent/';
+curl -v -X POST -H "X-Communication-Id: $X_COMMUNICATION_ID_ITG" -H "X-Auth-Token: $X_AUTH_TOKEN_ITG" -H "Content-Type: multipart/form-data" -F "file=@build/admin/crs8033_1en_us.zip" 'https://api-itg.support.hpe.com/document-loader/v1/pushcontent/'

--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -1,15 +1,13 @@
-## Install the UAN Product Stream
+# Install the UAN Product Stream
 
-This procedure installs the User Access Nodes \(UAN\) product on a system so that UAN boot images can be created.
+This procedure installs the User Access Nodes (UAN) product on a system so that UAN boot images can be created.
 
 Before performing this procedure:
 
-- Initialize and configure the Cray command line interface \(CLI\) tool. See "Configure the Cray Command Line Interface \(CLI\)" in the CSM documentation for more information.
-- Perform [Prepare for UAN Product Installation](installation_prereqs/Prepare_For_UAN_Product_Installation.md#prepare-for-uan-product-installation)
+- Initialize and configure the Cray command line interface (CLI) tool. See "Configure the Cray Command Line Interface (CLI)" in the CSM documentation for more information.
+- Perform [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md)
 
-Replace PRODUCT\_VERSION in the example commands with the UAN product stream string \(2.3.0 for example\). Replace CRAY\_EX\_DOMAIN in the example commands with the FQDN of the HPE Cray EX.
-
-**DOWNLOAD AND PREPARE THE UAN SOFTWARE PACKAGE**
+Replace `PRODUCT_VERSION` in the example commands with the UAN product stream string (2.3.0 for example). Replace `CRAY_EX_DOMAIN` in the example commands with the FQDN of the HPE Cray EX.
 
 1. Start a typescript to capture the commands and output from this installation.
 
@@ -24,24 +22,22 @@ Replace PRODUCT\_VERSION in the example commands with the UAN product stream str
     ncn-m001# ./install.sh
     ```
 
-**VERIFY THE INSTALLATION**
-
 3. Verify that the UAN configuration was imported and added to the `cray-product-catalog` ConfigMap in the Kubernetes `services` namespace.
 
-    a. Run the following command and verify that the output contains an entry for the PRODUCT\_VERSION that was installed in the previous steps:
+    1. Run the following command and verify that the output contains an entry for the `PRODUCT_VERSION` that was installed in the previous steps:
 
-    ```bash
-    ncn-m001# kubectl get cm cray-product-catalog -n services -o json | jq -r .data.uan
-    PRODUCT_VERSION:
-         configuration:
-           clone_url: https://vcs.CRAY_EX_DOMAIN/vcs/cray/uan-config-management.git
-           commit: 6658ea9e75f5f0f73f78941202664e9631a63726
-           import_branch: cray/uan/PRODUCT_VERSION
-           import_date: 2021-07-28 03:26:00.399670
-           ssh_url: git@vcs.CRAY_EX_DOMAIN:cray/uan-config-management.git
-    ```
+       ```bash
+       ncn-m001# kubectl get cm cray-product-catalog -n services -o json | jq -r .data.uan
+       PRODUCT_VERSION:
+            configuration:
+              clone_url: https://vcs.CRAY_EX_DOMAIN/vcs/cray/uan-config-management.git
+              commit: 6658ea9e75f5f0f73f78941202664e9631a63726
+              import_branch: cray/uan/PRODUCT_VERSION
+              import_date: 2021-07-28 03:26:00.399670
+              ssh_url: git@vcs.CRAY_EX_DOMAIN:cray/uan-config-management.git
+       ```
     
-    b. Verify that the Kubernetes jobs that import the configuration content completed successfully. Skip this step if the previous substep indicates that the new UAN product version content installed successfully.
+    2. Verify that the Kubernetes jobs that import the configuration content completed successfully. Skip this step if the previous substep indicates that the new UAN product version content installed successfully.
     
        A STATUS of `Completed` indicates that the Kubernetes jobs completed successfully.
     
@@ -54,12 +50,12 @@ Replace PRODUCT\_VERSION in the example commands with the UAN product stream str
 
    `PRODUCT_VERSION` is the UAN release number and `SLE_VERSION` is the SLE release version, such as `15sp2` or `15sp3`.
 
-    - Query Nexus through its REST API to display the repositories prefixed with the name uan:
+    Query Nexus through its REST API to display the repositories prefixed with the name uan:
    
-        ```bash
-        ncn-m001# curl -s -k https://packages.local/service/rest/v1/repositories | jq -r '.[] | select(.name | startswith("uan")) | .name'
-        uan-PRODUCT_VERSION-sle-SLE_VERSION
-        ```
+    ```bash
+    ncn-m001# curl -s -k https://packages.local/service/rest/v1/repositories | jq -r '.[] | select(.name | startswith("uan")) | .name'
+    uan-PRODUCT_VERSION-sle-SLE_VERSION
+    ```
    
 5. Finish the typescript file started at the beginning of this procedure.
 

--- a/docs/portal/developer-portal/install_publication.json
+++ b/docs/portal/developer-portal/install_publication.json
@@ -8,6 +8,7 @@
 "source_system_id": "GUID-9999999999-ABCD-9999-9999-9999999999",
 "source_system_version": "1",
 "lifecycle": "DRAFT",
+"products": ["1013083813"],
 "col_id": "crs8032",
 "full_title": "HPE Cray User Access Node (UAN) Software Installation Guide (S-8032)",
 "description": "This publication describes how to install and upgrade UAN product software.",

--- a/docs/portal/developer-portal/install_publication.json
+++ b/docs/portal/developer-portal/install_publication.json
@@ -1,0 +1,23 @@
+{
+"doc_id": "crs8032_1en_us",
+"content_version": "1",
+"document_part_number": "S-8032",
+"content_type": "htmlzip",
+"content_class": "html-default",
+"source_system": "SDL",
+"source_system_id": "GUID-9999999999-ABCD-9999-9999-9999999999",
+"source_system_version": "1",
+"lifecycle": "DRAFT",
+"col_id": "crs8032",
+"full_title": "HPE Cray User Access Node (UAN) Software Installation Guide (S-8032)",
+"description": "This publication describes how to install and upgrade UAN product software.",
+"creation_date": "2022-03-29T12:00:00",
+"content_update_date": "2022-03-29T13:00:00",
+"language_code": "en_US",
+"object_name": "crs8032_1en_us",
+"file_name": "crs8032_1en_us.zip",
+"submitter": "darrenn.jackson@hpe.com",
+"company_info": "HPE-green",
+"customer_available_date": "",
+"content_org": "CMG708"
+}

--- a/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_a_Gigabyte_UAN.md
+++ b/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_a_Gigabyte_UAN.md
@@ -1,4 +1,4 @@
-## Configure the BIOS of a Gigabyte UAN
+# Configure the BIOS of a Gigabyte UAN
 
 Perform this procedure to configure the network interface and boot settings required by Gigabyte UANs.
 
@@ -8,7 +8,7 @@ Before the UAN product can be installed on Gigabyte UANs, specific network inter
 
 2. Navigate to the boot menu.
 
-3. Set the **Boot Option \#1** field to `Network:UEFI: PXE IP4 Intel(R) I350 Gigabit Network Connection`.
+3. Set the **`Boot Option #1`** field to `Network:UEFI: PXE IP4 Intel(R) I350 Gigabit Network Connection`.
 
 4. Set all other **Boot Option** fields to `Disabled`.
 
@@ -26,7 +26,7 @@ Before the UAN product can be installed on Gigabyte UANs, specific network inter
 
 9. **Optional:** Run the following IPMI commands if the BIOS settings do not persist.
 
-    In these example commands, the BMC of the UAN is x3000c0s27b0. Replace USERNAME and PASSWORD with username and password of the BMC of the UAN. These commands do the following:
+    In these example commands, the BMC of the UAN is x3000c0s27b0. Replace `USERNAME` and `PASSWORD` with username and password of the BMC of the UAN. These commands do the following:
 
     - Power off the node
     - Perform a reset.

--- a/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md
+++ b/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md
@@ -1,4 +1,4 @@
-## Configure the BIOS of an HPE UAN
+# Configure the BIOS of an HPE UAN
 
 Perform this procedure to configure the network interface and boot settings required by HPE UANs.
 
@@ -8,7 +8,7 @@ Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iL
 
 1. Force a UAN to reboot into the BIOS.
 
-    In the following command, UAN\_BMC\_XNAME is the xname of the BMC of the UAN to configure. Replace USER and PASSWORD with the BMC username and password, respectively.
+    In the following command, `UAN_BMC_XNAME` is the xname of the BMC of the UAN to configure. Replace `USER` and `PASSWORD` with the BMC username and password, respectively.
 
     ```bash
     ncn-m001# ipmitool -U USER -P PASSWORD -H UAN_BMC_XNAME -I lanplus \
@@ -26,7 +26,7 @@ Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iL
 
 3. Press the **ESC** and **9** keys to access the BIOS System Utilities when the option appears.
 
-4. Ensure that OCP Slot 1 Port 1 is the only port with **Boot Mode** set to Network Boot \(PXE\). All other ports must have **Boot Mode** set to Disabled.
+4. Ensure that OCP Slot 10 Port 1 is the only port with **`Boot Mode`** set to Network Boot. All other ports must have **`Boot Mode`** set to Disabled.
 
     The settings must match the following example.
 
@@ -53,7 +53,7 @@ Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iL
         --------------------
     ```
 
-5. Set the **Link Speed** to SmartAN for all ports.
+5. Set the **`Link Speed`** to `SmartAN` for all ports.
 
     ```bash
         --------------------
@@ -122,19 +122,7 @@ Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iL
     ------------------------- 
     ```
 
-8. Ensure that the time is set correctly. 
+8. Refer to this [Setting the Date and Time](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00112581en_us&page=s_date_time.html) in the HPE UEFI documentation to set the correct date and time.
 
-   If the time is not set correctly, PXE booting issues may occur.
+   If the time is not set correctly, then PXE network booting issues may occur.
 
-    ```bash
-    -----------------------
-            System Utilities
-
-            System Information > Summary
-
-            System Name                                       HPE ProLiant DL385 Gen10 Plus
-            ...lines omitted...
-
-            Date and Time                                     2021-08-09T12:59:45-34:07
-            ------------------------- 
-    ```

--- a/docs/portal/developer-portal/installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md
+++ b/docs/portal/developer-portal/installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md
@@ -1,4 +1,4 @@
-## Configure the BMC for UANs with iLO
+# Configure the BMC for UANs with iLO
 
 Perform this procedure to enable the IPMI/DCMI settings on an HPE UAN that are necessary to continue UAN product installation on an HPE Cray EX supercomputer.
 
@@ -6,17 +6,17 @@ Perform the first three steps of [Prepare for UAN Product Installation](Prepare_
 
 1. Create the SSH tunnel necessary to access the BMC web GUI interface.
 
-    a. Find the IP or hostname for a UAN.
+   1. Find the IP or hostname for a UAN.
 
-    b. Create an SSH tunnel to the UAN BMC. Run the following command on an external system.
+   2. Create an SSH tunnel to the UAN BMC. Run the following command on an external system.
 
-        In the following example, `UAN_MGMT` is the UAN iLO interface host name or IP address. `NCN` is the host name or IP address of a non-compute node on the system. This example assumes that `NCN` allows port forwarding. `USER` will usually be `root`.
+      In the following example, `UAN_MGMT` is the UAN iLO interface host name or IP address. `NCN` is the host name or IP address of a non-compute node on the system. This example assumes that `NCN` allows port forwarding. `USER` will usually be `root`.
 
-        ```bash
-        $ ssh -L 8443:UAN_MGMT:443 USER@NCN
-        ```
+      ```bash
+      $ ssh -L 8443:UAN_MGMT:443 USER@NCN
+      ```
 
-    c. Wait for SSH to establish the connection.
+   3. Wait for SSH to establish the connection.
 
 2. Open https://127.0.0.1:8443 in web browser on the NCN to access the BMC web GUI.
 
@@ -32,4 +32,4 @@ Perform the first three steps of [Prepare for UAN Product Installation](Prepare_
 
 8. Ensure that the remote management settings match the following screenshot.
 
-![IPMI/DCMI configuration screen](installation_prereqs/images/HPE_UAN_BMC_IPMI_DCMI_configuration.png)
+![IPMI/DCMI configuration screen](images/HPE_UAN_BMC_IPMI_DCMI_configuration.png)

--- a/docs/portal/developer-portal/installation_prereqs/Hardware_and_Software_Prerequisites.md
+++ b/docs/portal/developer-portal/installation_prereqs/Hardware_and_Software_Prerequisites.md
@@ -1,0 +1,1 @@
+# Hardware and Software Prerequisites

--- a/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
+++ b/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
@@ -1,12 +1,12 @@
-## Prepare for UAN Product Installation
+# Prepare for UAN Product Installation
 
 Perform this procedure to ready the HPE Cray EX supercomputer for UAN product installation.
 
 Install and configure the COS product before performing this procedure.
 
-**MANAGEMENT NETWORK SWITCH CONFIGURATION**
+1. Verify that the management network switches are properly configured.
 
-1. Ensure that the management network switches are properly configured.
+   Refer to the [switch configuration procedures](https://github.com/Cray-HPE/docs-csm/tree/release/1.0/install) in the HPE Cray System Management Documentation.
 
 2. Ensure that the management network switches have the proper firmware.
 
@@ -16,32 +16,24 @@ Install and configure the COS product before performing this procedure.
 
     Refer to the procedure "Add UAN CAN IP Addresses to SLS" in the HPE Cray EX hardware documentation.
 
-**BMC CONFIGURATION**
-
 4. Configure the BMC of the UAN.
 
-    - Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md#configure-the-bmc-for-uans-with-ilo) if the UAN is a HPE server with an iLO.
-
-**BIOS CONFIGURATION**
+   Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md#configure-the-bmc-for-uans-with-ilo) if the UAN is a HPE server with an iLO.
 
 5. Configure the BIOS of the UAN.
 
     - Perform [Configure the BIOS of an HPE UAN](Configure_the_BIOS_of_an_HPE_UAN.md#configure-the-bios-of-an-hpe-uan) if the UAN is a HPE server with an iLO.
     - Perform [Configure the BIOS of a Gigabyte UAN](Configure_the_BIOS_of_a_Gigabyte_UAN.md#configure-the-bios-of-a-gigabyte-uan) if the UAN is a Gigabyte server.
 
-**VERIFY UAN BMC FIRMWARE VERSION**
-
 6. Verify that the firmware for each UAN BMC meets the specifications.
 
-    Use the System Admin Toolkit firmware command to check the current firmware version on a UAN node.
+   Use the System Admin Toolkit firmware command to check the current firmware version on a UAN node.
 
-    ```bash
-    ncn-m001# sat firmware -x BMC_XNAME
-    ```
+   ```bash
+   ncn-m001# sat firmware -x BMC_XNAME
+   ```
 
 7. Repeat the previous six Steps for all UANs.
-
-**VERIFY REQUIRED SOFTWARE FOR UAN INSTALLATION**
 
 8. Unpackage the file.
 
@@ -69,29 +61,30 @@ Install and configure the COS product before performing this procedure.
 
 11. Ensure that the `cray-console-node` pods are connected to UANs so that they are monitored and their consoles are logged.
 
-    a. Obtain a list of the xnames for all UANs (remove the `--subrole` argument to list all Application nodes).
+    1. Obtain a list of the xnames for all UANs (remove the `--subrole` argument to list all Application nodes).
 
-    ```bash
-    ncn# cray hsm state components list --role Application --subrole UAN --format json | jq -r .Components[].ID | sort
-    x3000c0s19b0n0
-    x3000c0s24b0n0
-    x3000c0s31b0n0
-    ```
+       ```bash
+       ncn# cray hsm state components list --role Application --subrole UAN --format json | jq -r .Components[].ID | sort
+       x3000c0s19b0n0
+       x3000c0s24b0n0
+       x3000c0s31b0n0
+       ```
     
-    b. Obtain a list of the console pods.
+    2. Obtain a list of the console pods.
 
-    ```bash
-    ncn# PODS=$(kubectl get pods -n services -l app.kubernetes.io/name=cray-console-node --template '{{range .items}}{{.metadata.name}} {{end}}')
-    ```
-    c. Use `conman -q` to scan the list of connections being monitored by conman (only UAN xnames are shown for brevity).
+       ```bash
+       ncn# PODS=$(kubectl get pods -n services -l app.kubernetes.io/name=cray-console-node --template '{{range .items}}{{.metadata.name}} {{end}}')
+       ```
+       
+    3. Use `conman -q` to scan the list of connections being monitored by conman (only UAN xnames are shown for brevity).
     
-    ```
-    ncn# for pod in $PODS; do kubectl exec -n services -c cray-console-node $pod -- conman -q; done
-    x3000c0s19b0n0
-    x3000c0s24b0n0
-    x3000c0s31b0n0
-    ```
+       ```
+       ncn# for pod in $PODS; do kubectl exec -n services -c cray-console-node $pod -- conman -q; done
+       x3000c0s19b0n0
+       x3000c0s24b0n0
+       x3000c0s31b0n0
+       ```
 
-    If a console connection is not present, the install may continue, but a console connection should be established before attempting to boot the UAN.
+       If a console connection is not present, the install may continue, but a console connection should be established before attempting to boot the UAN.
 
-Next, install the UAN product by peforming the procedure [Install the UAN Product Stream](../install/Install_the_UAN_Product_Stream.md#install-the-uan-product-stream).
+Next, install the UAN product by performing the procedure [Install the UAN Product Stream](../install/Install_the_UAN_Product_Stream.md#install-the-uan-product-stream).

--- a/docs/portal/developer-portal/operations/About_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/About_UAN_Configuration.md
@@ -1,8 +1,8 @@
-## About UAN Configuration
+# About UAN Configuration
 
 This section describes the Ansible playbooks and roles that configure UANs.
 
-### UAN configuration overview
+## UAN configuration overview
 
 Configuration of UAN nodes is performed by the Configuration Framework Service \(CFS\). CFS can apply configuration to both images and nodes. When the configuration is applied to nodes, the nodes must be booted and accessible through SSH over the Node Management Network \(NMN\).
 
@@ -20,7 +20,7 @@ The UAN roles in site.yml are required and must not be removed, with exception o
 
 For more information about these roles, see [UAN Ansible Roles](UAN_Ansible_Roles.md#uan-ansible-roles).
 
-### UAN network configuration
+## UAN network configuration
 
 The `uan_interfaces` role configures the interfaces on the UAN nodes in three phases:
 

--- a/docs/portal/developer-portal/operations/Boot_UANs.md
+++ b/docs/portal/developer-portal/operations/Boot_UANs.md
@@ -1,8 +1,8 @@
-## Boot UANs
+# Boot UANs
 
 Perform this procedure to boot UANs using BOS so that they are ready for user logins.
 
-Perform [Create UAN Boot Images](operations/Create_UAN_Boot_Images.md#create-uan-boot-images) before performing this procedure.
+Perform [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md) before performing this procedure.
 
 1. Create a BOS session to boot the UAN nodes.
 

--- a/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
+++ b/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
@@ -1,5 +1,5 @@
 
-## Build a New UAN Image Using a COS Recipe
+# Build a New UAN Image Using a COS Recipe
 
 Prior to UAN 2.3, a similar copy of the COS recipe was imported with the UAN install. In the UAN 2.3 release, UAN does not install a recipe, and a COS recipe must be used. Additional uan packages will now be installed via CFS and the `uan_packages` role.
 
@@ -12,38 +12,37 @@ In the COS recipe for 2.2, several dependencies have been removed, this includes
 
 1. Identify the COS image recipe to base the UAN image on. Select the recipe that matches the version of COS that the compute nodes will be using.
 
-```bash
-ncn-m001# cray ims recipes list --format json | jq '.[] | select(.name | contains("compute"))'
-{
-  "created": "2021-02-17T15:19:48.549383+00:00",
-  "id": "4a5d1178-80ad-4151-af1b-bbe1480958d1",  <<-- Note this ID
-  "link": {
-    "etag": "3c3b292364f7739da966c9cdae096964",
-    "path": "s3://ims/recipes/4a5d1178-80ad-4151-af1b-bbe1480958d1/recipe.tar.gz",
-    "type": "s3"
-  },
-  "linux_distribution": "sles15",
-  "name": "cray-shasta-compute-sles15sp3.x86_64-2.2.27",
-  "recipe_type": "kiwi-ng"
-}
-```
+   ```bash
+   ncn-m001# cray ims recipes list --format json | jq '.[] | select(.name | contains("compute"))'
+   {
+     "created": "2021-02-17T15:19:48.549383+00:00",
+     "id": "4a5d1178-80ad-4151-af1b-bbe1480958d1",  <<-- Note this ID
+     "link": {
+       "etag": "3c3b292364f7739da966c9cdae096964",
+       "path": "s3://ims/recipes/4a5d1178-80ad-4151-af1b-bbe1480958d1/recipe.tar.gz",
+       "type": "s3"
+     },
+     "linux_distribution": "sles15",
+     "name": "cray-shasta-compute-sles15sp3.x86_64-2.2.27",
+     "recipe_type": "kiwi-ng"
+   }
+   ```
 
 2. Save the id of the IMS recipe in an environment variable.
 
-```bash
-ncn-m001# IMS_RECIPE_ID=4a5d1178-80ad-4151-af1b-bbe1480958d1
-```
+   ```bash
+   ncn-m001# IMS_RECIPE_ID=4a5d1178-80ad-4151-af1b-bbe1480958d1
+   ```
 
 3. Use the IMS recipe id to build the UAN image:
 
    More detail on this IMS procedure may be found in the procedure "Build an Image Using IMS REST Service" in the CSM documentation.
 
-```bash
-ncn-m001# IMS_PUBLIC_KEY=$(cray ims public-keys list --format json | jq -r ".[] | .id" | head -1)
-ncn-m001# IMS_ARCHIVE_NAME=$(cray ims recipes describe $IMS_RECIPE_ID --format json | jq -r .name)
-ncn-m001# IMS_ARCHIVE_NAME=${IMS_ARCHIVE_NAME/compute/uan}
-
-ncn-m001# cray ims jobs create --job-type create --public-key-id $IMS_PUBLIC_KEY --image-root-archive-name $IMS_ARCHIVE_NAME --artifact-id $IMS_RECIPE_ID
-```
+   ```bash
+   ncn-m001# IMS_PUBLIC_KEY=$(cray ims public-keys list --format json | jq -r ".[] | .id" | head -1)
+   ncn-m001# IMS_ARCHIVE_NAME=$(cray ims recipes describe $IMS_RECIPE_ID --format json | jq -r .name)
+   ncn-m001# IMS_ARCHIVE_NAME=${IMS_ARCHIVE_NAME/compute/uan}
+   ncn-m001# cray ims jobs create --job-type create --public-key-id $IMS_PUBLIC_KEY --image-root-archive-name $IMS_ARCHIVE_NAME --artifact-id $IMS_RECIPE_ID
+   ```
 
 4. Perform [Create UAN Boot Images](Create_UAN_Boot_Images.md#create-boot-images) to run CFS Image Customization on the resulting image.

--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -1,5 +1,5 @@
 
-## Configure Interfaces on UANs
+# Configure Interfaces on UANs
 
 Perform this procedure to set network interfaces on UANs by editing a configuration file.
 

--- a/docs/portal/developer-portal/operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md
@@ -1,5 +1,5 @@
 
-## Configure Pluggable Authentication Modules \(PAM\) on UANs
+# Configure Pluggable Authentication Modules \(PAM\) on UANs
 
 Perform this procedure to configure PAM on UANs. This enables dynamic authentication support for system services.
 

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -128,7 +128,7 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 
     The following example shows how to add a `vars.yml` file containing site-specific configuration values to the `Application_UAN` group variable location.
 
-    These and other Ansible files do not necessarily need to be modified for UAN image creation. See [About UAN Configuration](operations/About_UAN_Configuration.md#about-uan-configuration) for instructions for site-specific UAN configuration, including CAN/CHN configuration.
+    These and other Ansible files do not necessarily need to be modified for UAN image creation. See [About UAN Configuration](About_UAN_Configuration.md#about-uan-configuration) for instructions for site-specific UAN configuration, including CAN/CHN configuration.
 
     ```bash
     ncn-m001# vim group_vars/Application_UAN/vars.yml

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -1,5 +1,5 @@
 
-## Create UAN Boot Images
+# Create UAN Boot Images
 
 This procedure updates the configuration management git repository to match the installed version of the UAN product. That updated configuration is then used to create UAN boot images and a BOS session template.
 

--- a/docs/portal/developer-portal/operations/Mount_a_New_File_System_on_an_UAN.md
+++ b/docs/portal/developer-portal/operations/Mount_a_New_File_System_on_an_UAN.md
@@ -1,9 +1,9 @@
 
-## Mount a New File System on a UAN
+# Mount a New File System on a UAN
 
 Perform this procedure to create a mount point for a new file system on a UAN.
 
-1. Perform Steps 1-9 of [Create UAN Boot Images](operations/Create_UAN_Boot_Images.md#create-uan-boot-images).
+1. Perform Steps 1-9 of [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md).
 
 2. Create a directory for `Application` role nodes.
 
@@ -36,4 +36,4 @@ Perform this procedure to create a mount point for a new file system on a UAN.
     ncn-w001# git commit -am 'Added file system info'
     ```
 
-6. Resume [Create UAN Boot Images](operations/Create_UAN_Boot_Images.md#create-uan-boot-images) at Step 10. 
+6. Resume [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md) at Step 10. 

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -164,35 +164,35 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-#### `uan_can_setup` (Deprecated)
+`uan_can_setup` (Deprecated)
 
-This variable is deprecated and `uan_user_access_cfg` should be used.
+: This variable is deprecated and `uan_user_access_cfg` should be used.
 
-`uan_can_setup` is a boolean variable controlling the configuration of user
+: `uan_can_setup` is a boolean variable controlling the configuration of user
 access to UAN nodes over the Customer Access Network (CAN).  The CAN is a VLAN
 on the Node Management Network (NMN).
 
-When `uan_can_setup` has a true value, the default route is set to be on the CAN
+: When `uan_can_setup` has a true value, the default route is set to be on the CAN
 unless `uan_customer_default_route` has a true value.  If `uan_can_setup` has a
 false value, user access over the CAN is not configured on the UAN nodes and no
 default route configured.  The admin must then specify the default route in
 `customer_uan_routes`.
 
-The default value of `uan_can_setup` is `no`.
+: The default value of `uan_can_setup` is `no`.
 
-Example:
+  Example:
 
   ```yaml
   uan_can_setup: no
   ```
 
-#### `uan_user_access_cfg`
+`uan_user_access_cfg`
 
-`uan_user_access_cfg` defines the way users access the UAN nodes.  UANs may be
+: `uan_user_access_cfg` defines the way users access the UAN nodes.  UANs may be
 configured to use a VLAN over the Node Management Network (CAN), a subnet on the
 High Speed Network (CHN), or a direct connection to a site network (DIRECT).
 
-Valid values for `uan_user_access_cfg` are `"CAN"`, `"CHN"`, or `"DIRECT"`.  The
+: Valid values for `uan_user_access_cfg` are `"CAN"`, `"CHN"`, or `"DIRECT"`.  The
 default value is `"DIRECT"`.  With `uan_user_access_cfg: "DIRECT"`, the admin
 must define the interface and and routing to use.  See `customer_uan_interfaces`
 and `customer_uan_routes`.  With `uan_user_access_cfg: "CAN"` or
@@ -200,40 +200,43 @@ and `customer_uan_routes`.  With `uan_user_access_cfg: "CAN"` or
 respectively, unless `uan_customer_default_route` has a true value.  Then the
 admin must define a default route in `customer_uan_routes`.
 
-Example:
+  Example:
 
-```yaml
-uan_user_access_cfg: "CHN"
-```
+  ```yaml
+  uan_user_access_cfg: "CHN"
+  ```
 
-##### `uan_customer_default_route`
+`uan_customer_default_route`
 
-`uan_customer_default_route` is a boolean variable that allows the default route
+: `uan_customer_default_route` is a boolean variable that allows the default route
 to be set by the `customer_uan_routes` data when `uan_user_access_cfg` is set to
 CAN or CHN.
 
-By default, no default route is setup unless `uan_user_access_cfg` is set to
+: By default, no default route is setup unless `uan_user_access_cfg` is set to
 either `"CAN"` or `"CHN"` which sets the default route to the CAN or CHN,
 respectively.
 
-```yaml
-uan_customer_default_route: no
-```
+  Example:
 
-##### `valid_uan_user_access_cfgs`
+  ```yaml
+  uan_customer_default_route: no
+  ```
 
-`valid_uan_user_access_cfgs` is a list of valid values for `uan_user_access_cfg`.
+`valid_uan_user_access_cfgs`
+
+: `valid_uan_user_access_cfgs` is a list of valid values for `uan_user_access_cfg`.
 This value should not be changed.
 
-```yaml
-valid_uan_user_access_cfgs:
-  - "DIRECT"
-  - "CAN"
-  - "CHN"
-```
-##### `sls_nmn_name`
+  ```yaml
+  valid_uan_user_access_cfgs:
+    - "DIRECT"
+    - "CAN"
+    - "CHN"
+  ```
 
-`sls_nmn_name` is the Node Management Network name used by SLS.
+`sls_nmn_name`
+
+: `sls_nmn_name` is the Node Management Network name used by SLS.
 This value should not be changed.
 
   Example:
@@ -242,23 +245,16 @@ This value should not be changed.
   sls_nmn_name: "NMN"
   ```
 
-`sls_nmn_svcs_name` is the Node Management Services Network name used by SLS.
+`sls_nmn_svcs_name`
+
+: is the Node Management Services Network name used by SLS.
 This value should not be changed.
-
-##### `uan_required_dns_options`
-
-`uan_required_dns_options` is a list of DNS options.  By default, `single-request` is set and must not be removed.
-
-Example:
-
-```yaml
-uan_required_dns_options:
-  - 'single-request'
-```
 
 `uan_required_dns_options`
 
 : `uan_required_dns_options` is a list of DNS options.  By default, `single-request` is set and must not be removed.
+
+  Example:
 
   ```yaml
   uan_required_dns_options:
@@ -313,15 +309,15 @@ uan_required_dns_options:
 
   Example:
 
-```yaml
-  customer_uan_rules:
-    - name: "net1"
-      rules:
-        - "from 10.1.0.0/16 lookup 1"
-    - name: "net2"
-      rules:
-        - "from 10.103.8.0/24 lookup 3"
-  ```
+  ```yaml
+    customer_uan_rules:
+      - name: "net1"
+        rules:
+          - "from 10.1.0.0/16 lookup 1"
+      - name: "net2"
+        rules:
+          - "from 10.103.8.0/24 lookup 3"
+    ```
 
 `customer_uan_global_routes`
 
@@ -331,7 +327,7 @@ the "routes" file.
   Example:
 
   ```yaml
-    customer_uan_global_routes:
+  customer_uan_global_routes:
     - routes:
       - "10.92.100.0 10.252.0.1 255.255.255.0 -"
       - "10.100.0.0 10.252.0.1 255.255.128.0 -"

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -375,8 +375,7 @@ to the `/etc/resolv.conf` DNS options list.
 
 `uan_access_control`
 
-`uan_access_control` is a boolean variable to control whether non-root access
-control is enabled.  Default is `no`.
+: `uan_access_control` is a boolean variable to control whether non-root access control is enabled.  Default is `no`.
 
   Example:
 

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -1,11 +1,11 @@
-## UAN Ansible Roles
+# UAN Ansible Roles
 
-### uan_disk_config
+## `uan_disk_config`
 
 The `uan_disk_config` role configures swap and scratch disk partitions on UAN
 nodes.
 
-#### Requirements
+### Requirements
 
 There must be disk devices found on the UAN node by the `device_filter` module
 or this role will exit with failure. This condition can be ignored by setting
@@ -17,112 +17,131 @@ The device that is found will be unmounted if mounted and a swap partition will
 be created on the first half of the disk, and a scratch partition on the second
 half. ext4 filesystems are created on each partition.
 
-#### Role Variables
+### Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-##### `uan_require_disk`
+`uan_require_disk`
 
-Boolean to determine if this role continues to setup disk if no disks were found
-by the device filter. Set to `true` to exit with error when no disks are found.
+: Boolean to determine if this role continues to setup disk if no disks were found
+by the device filter. Set to `true` to exit with error when no disks are found. 
 
-```yaml
-uan_require_disk: false
-```
+  Example:
 
-##### `uan_device_name_filter`
+  ```yaml
+  uan_require_disk: false
+  ```
 
-Regular expression of disk device name for this role to filter.
+`uan_device_name_filter`
+
+: Regular expression of disk device name for this role to filter.
 Input to the `device_filter` module.
 
-```yaml
-uan_device_name_filter: "^sd[a-f]$"
-```
+  Example:
 
-##### `uan_device_host_filter`
+  ```yaml
+  uan_device_name_filter: "^sd[a-f]$"
+  ```
 
-Regular expression of host for this role to filter.
+`uan_device_host_filter`
+
+: Regular expression of host for this role to filter.
 Input to the `device_filter` module.
 
-```yaml
-uan_device_host_filter: ""
-```
+  Example:
 
-##### `uan_device_model_filter`
+  ```yaml
+  uan_device_host_filter: ""
+  ```
 
-Regular expression of device model for this role to filter.
+`uan_device_model_filter`
+
+: Regular expression of device model for this role to filter.
 Input to the `device_filter` module.
 
-```yaml
-uan_device_model_filter: ""
-```
+  Example:
 
-##### `uan_device_vendor_filter`
+  ```yaml
+  uan_device_model_filter: ""
+  ```
 
-Regular expression of disk vendor for this role to filter.
+`uan_device_vendor_filter`
+
+: Regular expression of disk vendor for this role to filter.
 Input to the `device_filter` module.
 
-```yaml
-uan_device_vendor_filter: ""
-```
+  Example:
 
-##### `uan_device_size_filter`
+  ```yaml
+  uan_device_vendor_filter: ""
+  ```
 
+`uan_device_size_filter`
 
-Regular expression of disk size for this role to filter.
+: Regular expression of disk size for this role to filter.
 Input to the `device_filter` module.
 
-```yaml
-uan_device_size_filter: "<1TB"
-```
+  Example: 
+  
+  ```yaml
+  uan_device_size_filter: "<1TB"
+  ```
 
-##### `uan_swap`
+`uan_swap`
 
-Filesystem location to mount the swap partition.
+: Filesystem location to mount the swap partition.
 
-```yaml
-uan_swap: "/swap"
-```
+  Example:
 
-##### `uan_scratch`
+  ```yaml
+  uan_swap: "/swap"
+  ```
 
-Filesystem location to mount the scratch partition.
+`uan_scratch`
 
-```yaml
-uan_scratch: "/scratch"
-```
+: Filesystem location to mount the scratch partition.
 
-##### `swap_file`
+  Example:
 
-Name of the swapfile to create. Full path is `<uan_swap>/<swapfile>`.
+  ```yaml
+  uan_scratch: "/scratch"
+  ```
 
-```yaml
-swap_file: "swapfile"
-```
+`swap_file`
 
-##### `swap_dd_command`
+: Name of the swapfile to create. Full path is `<uan_swap>/<swapfile>`.
 
-`dd` command to create the `swapfile`.
+  Example:
 
-```yaml
-swap_dd_command: "/usr/bin/dd if=/dev/zero of={{ uan_swap }}/{{ swap_file }} bs=1GB count=10"
-```
+  ```yaml
+  swap_file: "swapfile"
+  ```
 
-##### swap_swappiness
+`swap_dd_command`
 
-Value to set the swapiness in sysctl.
+: `dd` command to create the `swapfile`.
 
-```yaml
-swap_swappiness: "10"
-```
+  Example:
 
-#### Dependencies
+  ```yaml
+  swap_dd_command: "/usr/bin/dd if=/dev/zero of={{ uan_swap }}/{{ swap_file }} bs=1GB count=10"
+  ```
 
+`swap_swappiness`
+
+: Value to set the swapiness in sysctl.
+
+  Example:
+
+  ```yaml
+  swap_swappiness: "10"
+  ```
+
+### Dependencies
 
 `library/device_filter.py` is required to find eligible disk devices.
 
-#### Example Playbook
-
+### Example Playbook
 
 ```yaml
 - hosts: Application_UAN
@@ -132,20 +151,20 @@ swap_swappiness: "10"
 
 This role is included in the UAN `site.yml` play.
 
-### uan_interfaces
+## `uan_interfaces`
 
 The `uan_interfaces` role configures site/customer-defined network interfaces
 and Shasta Customer Access Network (CAN) network interfaces on UAN nodes.
 
-#### Requirements
+### Requirements
 
 None.
 
-#### Role Variables
+### Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-##### `uan_can_setup` (Deprecated)
+#### `uan_can_setup` (Deprecated)
 
 This variable is deprecated and `uan_user_access_cfg` should be used.
 
@@ -161,11 +180,13 @@ default route configured.  The admin must then specify the default route in
 
 The default value of `uan_can_setup` is `no`.
 
-```yaml
-uan_can_setup: no
-```
+Example:
 
-##### `uan_user_access_cfg`
+  ```yaml
+  uan_can_setup: no
+  ```
+
+#### `uan_user_access_cfg`
 
 `uan_user_access_cfg` defines the way users access the UAN nodes.  UANs may be
 configured to use a VLAN over the Node Management Network (CAN), a subnet on the
@@ -178,6 +199,8 @@ and `customer_uan_routes`.  With `uan_user_access_cfg: "CAN"` or
 `uan_user_access_cfg: "CHN"`, the default route will be set to the CAN or CHN,
 respectively, unless `uan_customer_default_route` has a true value.  Then the
 admin must define a default route in `customer_uan_routes`.
+
+Example:
 
 ```yaml
 uan_user_access_cfg: "CHN"
@@ -213,201 +236,193 @@ valid_uan_user_access_cfgs:
 `sls_nmn_name` is the Node Management Network name used by SLS.
 This value should not be changed.
 
-```yaml
-sls_nmn_name: "NMN"
-```
+  Example:
 
-##### `sls_nmn_svcs_name`
+  ```yaml
+  sls_nmn_name: "NMN"
+  ```
 
 `sls_nmn_svcs_name` is the Node Management Services Network name used by SLS.
 This value should not be changed.
 
-```yaml
-sls_nmn_svcs_name: "NMNLB"
-```
-
-##### `sls_mnmn_svcs_name`
-
-`sls_mnmn_svcs_name` is the Mountain Node Management Services Network name used
-by SLS.  This value should not be changed.
-
-```yaml
-sls_mnmn_svcs_name: "NMN_MTN"
-```
-
 ##### `uan_required_dns_options`
 
 `uan_required_dns_options` is a list of DNS options.  By default, `single-request` is set and must not be removed.
+
+Example:
 
 ```yaml
 uan_required_dns_options:
   - 'single-request'
 ```
 
-##### `customer_uan_interfaces`
+`uan_required_dns_options`
 
-`customer_uan_interfaces` is as list of interface names used for constructing
-`ifcfg-<customer_uan_interfaces.name>` files. Define ifcfg fields for each
-interface here. Field names are converted to uppercase in the generated
-`ifcfg-<name>` file(s).
+: `uan_required_dns_options` is a list of DNS options.  By default, `single-request` is set and must not be removed.
 
-Interfaces should be defined in order of dependency.
+  ```yaml
+  uan_required_dns_options:
+    - 'single-request'
+  ```
+
+`customer_uan_interfaces`
+
+: `customer_uan_interfaces` is as list of interface names used for constructing `ifcfg-<customer_uan_interfaces.name>` files. Define ifcfg fields for each interface here. Field names are converted to uppercase in the generated `ifcfg-<name>` file(s).
+
+  Interfaces should be defined in order of dependency.
+  
+  Example:
+
+  ```yaml
+  customer_uan_interfaces:
+    - name: "net1"
+      settings:
+        bootproto: "static"
+        device: "net1"
+        ipaddr: "1.2.3.4"
+        startmode: "auto"
+    - name: "net2"
+      settings:
+        bootproto: "static"
+        device: "net2"
+        ipaddr: "5.6.7.8"
+        startmode: "auto"
+  ```
+
+`customer_uan_routes`
+
+: `customer_uan_routes` is as list of interface routes used for constructing `ifroute-<customer_uan_routes.name>` files.
+
+  Example:
+
+  ```yaml
+  customer_uan_routes:
+    - name: "net1"
+      routes:
+        - "10.92.100.0 10.252.0.1 255.255.255.0 -"
+        - "10.100.0.0 10.252.0.1 255.255.128.0 -"
+    - name: "net2"
+      routes:
+        - "default 10.103.8.20 255.255.255.255 - table 3"
+        - "10.103.8.128/25 10.103.8.20 255.255.255.255 net2"
+  ```
+
+`customer_uan_rules`
+
+: `customer_uan_rules` is as list of interface rules used for constructing `ifrule-<customer_uan_routes.name>` files.
+
+  Example:
 
 ```yaml
-customer_uan_interfaces: []
+  customer_uan_rules:
+    - name: "net1"
+      rules:
+        - "from 10.1.0.0/16 lookup 1"
+    - name: "net2"
+      rules:
+        - "from 10.103.8.0/24 lookup 3"
+  ```
 
-# Example:
-customer_uan_interfaces:
-  - name: "net1"
-    settings:
-      bootproto: "static"
-      device: "net1"
-      ipaddr: "1.2.3.4"
-      startmode: "auto"
-  - name: "net2"
-    settings:
-      bootproto: "static"
-      device: "net2"
-      ipaddr: "5.6.7.8"
-      startmode: "auto"
-```
+`customer_uan_global_routes`
 
-##### `customer_uan_routes`
-
-`customer_uan_routes` is as list of interface routes used for constructing
-`ifroute-<customer_uan_routes.name>` files.
-
-```yaml
-customer_uan_routes: []
-
-# Example
-customer_uan_routes:
-  - name: "net1"
-    routes:
-      - "10.92.100.0 10.252.0.1 255.255.255.0 -"
-      - "10.100.0.0 10.252.0.1 255.255.128.0 -"
-  - name: "net2"
-    routes:
-      - "default 10.103.8.20 255.255.255.255 - table 3"
-      - "10.103.8.128/25 10.103.8.20 255.255.255.255 net2"
-```
-
-##### `customer_uan_rules`
-
-`customer_uan_rules` is as list of interface rules used for constructing
-`ifrule-<customer_uan_routes.name>` files.
-
-```yaml
-customer_uan_rules: []
-
-# Example
-customer_uan_rules:
-  - name: "net1"
-    rules:
-      - "from 10.1.0.0/16 lookup 1"
-  - name: "net2"
-    rules:
-      - "from 10.103.8.0/24 lookup 3"
-```
-
-##### `customer_uan_global_routes`
-
-`customer_uan_global_routes` is a list of global routes used for constructing
+: `customer_uan_global_routes` is a list of global routes used for constructing
 the "routes" file.
 
-```yaml
-customer_uan_global_routes: []
+  Example:
 
-# Example
-customer_uan_global_routes:
-  - routes:
-    - "10.92.100.0 10.252.0.1 255.255.255.0 -"
-    - "10.100.0.0 10.252.0.1 255.255.128.0 -"
-```
+  ```yaml
+    customer_uan_global_routes:
+    - routes:
+      - "10.92.100.0 10.252.0.1 255.255.255.0 -"
+      - "10.100.0.0 10.252.0.1 255.255.128.0 -"
+  ```
 
-##### `external_dns_searchlist`
+`external_dns_searchlist`
 
-`external_dns_searchlist` is a list of customer-configurable fields to be added
-to the `/etc/resolv.conf` DNS search list.
+: `external_dns_searchlist` is a list of customer-configurable fields to be added to the `/etc/resolv.conf` DNS search list.
 
-```yaml
-external_dns_searchlist: [ '' ]
+  Example:
 
-# Example
-external_dns_searchlist:
-  - 'my.domain.com'
-  - 'my.other.domain.com'
-```
+  ```yaml
+  external_dns_searchlist:
+    - 'my.domain.com'
+    - 'my.other.domain.com'
+  ```
 
-##### `external_dns_servers`
+`external_dns_servers`
 
-`external_dns_servers` is a list of customer-configurable fields to be added
-to the `/etc/resolv.conf` DNS server list.
+: `external_dns_servers` is a list of customer-configurable fields to be added to the `/etc/resolv.conf` DNS server list.
 
-```yaml
-external_dns_servers: [ '' ]
+  Example:
 
-# Example
-external_dns_servers:
-  - '1.2.3.4'
-  - '5.6.7.8'
-```
+  ```yaml
+  external_dns_servers:
+    - '1.2.3.4'
+    - '5.6.7.8'
+  ```
 
-##### `external_dns_options`
+`external_dns_options`
 
-`external_dns_options` is a list of customer-configurable fields to be added
+: `external_dns_options` is a list of customer-configurable fields to be added
 to the `/etc/resolv.conf` DNS options list.
 
-```yaml
-external_dns_options: [ '' ]
+  Example:
 
-# Example
-external_dns_options:
-  - 'single-request'
-```
+  ```yaml
+  external_dns_options:
+    - 'single-request'
+  ```
 
-##### `uan_access_control`
+`uan_access_control`
 
 `uan_access_control` is a boolean variable to control whether non-root access
 control is enabled.  Default is `no`.
 
-```yaml
-uan_access_control: no
-```
+  Example:
 
-##### `api_gateways`
+  ```yaml
+  uan_access_control: no
+  ```
 
-`api_gateways` is a list of API gateway DNS names to block non-user access
+`api_gateways`
 
-```yaml
-api_gateways:
-  - "api-gw-service"
-  - "api-gw-service.local"
-  - "api-gw-service-nmn.local"
-  - "kubeapi-vip"
-```
+: `api_gateways` is a list of API gateway DNS names to block non-user access
 
-##### `api_gw_ports`
+  Example:
+  
+  ```yaml
+  api_gateways:
+    - "api-gw-service"
+    - "api-gw-service.local"
+    - "api-gw-service-nmn.local"
+    - "kubeapi-vip"
+  ```
 
-`api_gw_ports` is a list of gateway ports to protect.
+`api_gw_ports`
 
-```yaml
-api_gw_ports: "80,443,8081,8888"
-```
+: `api_gw_ports` is a list of gateway ports to protect.
 
-##### `sls_url`
+  Example:
 
-`sls_url` is the SLS URL.
+  ```yaml
+  api_gw_ports: "80,443,8081,8888"
+  ```
 
-```yaml
-sls_url: "http://cray-sls"
-```
+`sls_url`
 
-#### Dependencies
+: `sls_url` is the SLS URL.
+
+  Example:
+
+  ```yaml
+  sls_url: "http://cray-sls"
+  ```
+
+### Dependencies
 
 None.
 
-#### Example Playbook
+### Example Playbook
 
 ```yaml
 - hosts: Application_UAN
@@ -417,74 +432,76 @@ None.
 
 This role is included in the UAN `site.yml` play.
 
-### uan_ldap
+## `uan_ldap`
 
 The `uan_ldap` role configures LDAP and AD groups on UAN nodes.
 
-#### Requirements
+### Requirements
 
 NSCD, pam-config, sssd.
 
-#### Role Variables
+### Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-`uan_ldap_setup` is a boolean variable to selectively skip the setup of LDAP on nodes it
-would otherwise be configured due to `uan_ldap_config` being defined.  The default setting
-is to setup LDAP when `uan_ldap_config` is not empty.
+`uan_ldap_setup` 
 
-```yaml
-uan_ldap_setup: yes
-```
+: A boolean variable to selectively skip the setup of LDAP on nodes it would otherwise be configured due to `uan_ldap_config` being defined.  The default setting is to setup LDAP when `uan_ldap_config` is not empty.
 
-`uan_ldap_config` configures LDAP domains and servers. If this list is empty,
-no LDAP configuration will be applied to the UAN targets and all role tasks will
-be skipped.
+  Example:
 
-```yaml
-uan_ldap_config: []
+  ```yaml
+  uan_ldap_setup: yes
+  ```
 
-# Example
-uan_ldap_config:
-  - domain: "mydomain-ldaps"
-    search_base: "dc=...,dc=..."
-    servers: ["ldaps://123.123.123.1", "ldaps://213.312.123.132"]
-    chpass_uri: ["ldaps://123.123.123.1"]
+`uan_ldap_config` 
 
-  - domain: "mydomain-ldap"
-    search_base: "dc=...,dc=..."
-    servers: ["ldap://123.123.123.1", "ldap://213.312.123.132"]
+: Configures LDAP domains and servers. If this list is empty, no LDAP configuration will be applied to the UAN targets and all role tasks will be skipped.
 
-```
+  Example:
 
-`uan_ad_groups` configures active directory groups on UAN nodes.
+  ```yaml
+  uan_ldap_config:
+    - domain: "mydomain-ldaps"
+      search_base: "dc=...,dc=..."
+      servers: ["ldaps://123.123.123.1", "ldaps://213.312.123.132"]
+      chpass_uri: ["ldaps://123.123.123.1"]
 
-```yaml
-uan_ad_groups: []
+    - domain: "mydomain-ldap"
+      search_base: "dc=...,dc=..."
+      servers: ["ldap://123.123.123.1", "ldap://213.312.123.132"]
+  ```
 
-# Example
-uan_ad_groups:
-  - { name: admin_grp, origin: ALL }
-  - { name: dev_users, origin: ALL }
-```
+`uan_ad_groups` 
 
-`uan_pam_modules` configures PAM modules on the UAN nodes in `/etc/pam.d`.
+: Configures active directory groups on UAN nodes.
 
-```yaml
-uan_pam_modules: []
+  Example:
 
-# Example
-uan_pam_modules:
-  - name: "common-account"
-    lines:
-      - "account required\tpam_access.so"
-```
+  ```yaml
+  uan_ad_groups:
+    - { name: admin_grp, origin: ALL }
+    - { name: dev_users, origin: ALL }
+  ```
 
-#### Dependencies
+`uan_pam_modules` 
+
+: Configures PAM modules on the UAN nodes in `/etc/pam.d`.
+
+  Example:
+
+  ```yaml
+  uan_pam_modules:
+    - name: "common-account"
+      lines:
+        - "account required\tpam_access.so"
+  ```
+
+### Dependencies
 
 None.
 
-#### Example Playbook
+### Example Playbook
 
 ```yaml
 - hosts: Application_UAN
@@ -494,15 +511,15 @@ None.
 
 This role is included in the UAN `site.yml` play.
 
-### uan_motd
+## uan_motd
 
 The `uan_motd` role appends text to the `/etc/motd` file.
 
-#### Requirements
+### Requirements
 
 None.
 
-#### Role Variables
+### Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
@@ -510,13 +527,15 @@ Available variables are listed below, along with default values (see `defaults/m
 uan_motd_content: []
 ```
 
-`uan_motd_content` contains text to be added to the end of the `/etc/motd` file.
+`uan_motd_content` 
 
-#### Dependencies
+: Contains text to be added to the end of the `/etc/motd` file.
+
+### Dependencies
 
 None.
 
-#### Example Playbook
+### Example Playbook
 
 ```yaml
 - hosts: Application_UAN
@@ -526,7 +545,7 @@ None.
 
 This role is included in the UAN `site.yml` play.
 
-### uan_packages
+## uan_packages
 
 The `uan_packages` role installs additional RPMs on UANs using the Ansible
 `zypper` module.
@@ -539,11 +558,11 @@ on large systems.
 
 This role will only run on SLES-based nodes.
 
-#### Requirements
+### Requirements
 
 Zypper must be installed.
 
-#### Role Variables
+### Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
@@ -551,13 +570,15 @@ Available variables are listed below, along with default values (see `defaults/m
 uan_additional_sles15_packages: []
 ```
 
-`uan_additional_sles15_packages` contains the list of RPM packages to install.
+`uan_additional_sles15_packages` 
 
-#### Dependencies
+: contains the list of RPM packages to install.
+
+### Dependencies
 
 None.
 
-#### Example Playbook
+### Example Playbook
 
 ```yaml
 - hosts: Application_UAN
@@ -567,64 +588,73 @@ None.
 
 This role is included in the UAN `site.yml` play.
 
-
-### uan_shadow
+## uan_shadow
 
 The `uan_shadow` role configures the root password on UAN nodes.
 
-#### Requirements
+### Requirements
 
 The root password hash has to be installed in HashiCorp Vault at `secret/uan root_password`.
 
-#### Role Variables
+### Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-##### `uan_vault_url`
+`uan_vault_url`
 
-`uan_vault_url` is the URL for the HashiCorp Vault
+: The URL for the HashiCorp Vault
 
-```yaml
-uan_vault_url: "http://cray-vault.vault:8200"
-```
+  Example:
 
-##### `uan_vault_role_file`
+  ```yaml
+  uan_vault_url: "http://cray-vault.vault:8200"
+  ```
 
-`uan_vault_role_file` is the required Kubernetes role file for HashiCorp Vault access.
+`uan_vault_role_file`
 
-```yaml
-uan_vault_role_file: /var/run/secrets/kubernetes.io/serviceaccount/namespace
-```
+: The required Kubernetes role file for HashiCorp Vault access.
 
-##### `uan_vault_jwt_file`
+  Example:
 
-`uan_vault_jwt_file` is the path to the required Kubernetes token file for HashiCorp Vault access.
+  ```yaml
+  uan_vault_role_file: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+  ```
 
-```yaml
-uan_vault_jwt_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-```
+`uan_vault_jwt_file`
 
-##### `uan_vault_path`
+: The path to the required Kubernetes token file for HashiCorp Vault access.
 
-`uan_vault_path` is the path to use for storing data for UANs in HashiCorp Vault.
+  Example:
 
-```yaml
-uan_vault_path: secret/uan
-```
+  ```yaml
+  uan_vault_jwt_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  ```
 
-##### `uan_vault_key`
+`uan_vault_path`
 
-`uan_vault_key` is the key used for storing the root password in HashiCorp Vault.
+: The path to use for storing data for UANs in HashiCorp Vault.
 
-```yaml
-uan_vault_key: root_password
-```
+  Example:
 
-#### Dependencies
+  ```yaml
+  uan_vault_path: secret/uan
+  ```
+
+`uan_vault_key`
+
+: The key used for storing the root password in HashiCorp Vault.
+
+  Example:
+
+  ```yaml
+  uan_vault_key: root_password
+  ```
+
+### Dependencies
 
 None.
 
-#### Example Playbook
+### Example Playbook
 
 
 ```yaml

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Boot_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Boot_Issues.md
@@ -1,7 +1,7 @@
 
-## Troubleshoot UAN Boot Issues
+# Troubleshoot UAN Boot Issues
 
-### The UAN boot process
+## The UAN boot process
 
 BOS boots UANs. BOS uses session templates to define various parameters such as:
 
@@ -19,13 +19,13 @@ UAN boots are performed in three phases:
     2. Mounting the rootfs
 3. Booting the UAN image rootfs.
 
-### PXE Issues
+## PXE Issues
 
 Most PXE boot failures are the result of misconfigured network switches and/or BIOS settings. The UAN must PXE boot over the Node Management Network \(NMN\) and the switches must be configured to allow connectivity to the NMN. The cable for the NMN must be connected to the first port of the OCP card on HPE DL325 and DL385 servers or to the first port of the built-in LAN-On-Motherboard \(LOM\) on Gigabyte servers. See "Prepare for UAN Product Installation" in the UAN Installation Guide for details on the switch and BIOS settings required to configure the UAN for PXE booting.
 
 UANs may fail to boot when the BIOS EFITIME is too far away from the time on management nodes. If there are x509 certificate problems, check that the BIOS time is correct. See "Configure the BIOS of an HPE UAN" or "Configure the BIOS of a Gigabyte UAN" in the UAN Installation Guide for examples of checking settings in the BIOS.
 
-### Initrd \(Dracut\) Issues
+## Initrd \(Dracut\) Issues
 
 Dracut failures are often caused by the wrong interface being named `nmn0`, or to multiple entries for the UAN xname in DNS. The latter is a result of multiple interfaces making DHCP requests. Either condition can cause IP address mismatches in the `dvs_node_map`. DNS configures entries based on DHCP leases.
 
@@ -49,7 +49,7 @@ ncn-w002
 
 If DVS and CPS are both healthy, then both of these commands will return all the worker NCNs in the HPE Cray EX system.
 
-### Image Boot Issues
+## Image Boot Issues
 
 Once dracut exits, the UAN will boot the `rootfs` image. Failures seen in this phase tend to be failures of `spire-agent`, `cfs-state-reporter`, or both. The `cfs-state-reporter` tells BOA that the node is ready and allows BOA to start CFS for Node Personalization. If `cfs-state-reporter` does not start, check if the `spire-agent` has started. The `cfs-state-reporter` depends on the `spire-agent`. Running systemctl status spire-agent will show that that service is enabled and running if there are no issues with that service. Similarly, running `systemctl status cfs-state-reporter` will show a status of SUCCESS.
 

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md
@@ -1,5 +1,5 @@
 
-## Troubleshoot UAN CFS and Network Configuration Issues
+# Troubleshoot UAN CFS and Network Configuration Issues
 
 Examine the UAN CFS pod logs to help troubleshoot CFS and networking issues on UANs.
 

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md
@@ -1,5 +1,5 @@
 
-## Troubleshoot UAN Disk Configuration Issues
+# Troubleshoot UAN Disk Configuration Issues
 
 Perform this procedure to enable `uan_disk_config` to run successfully by erasing existing disk partitions. UAN disk configuration will fail if the disk on the node is already partitioned. Manually erase any existing partitions to fix the issue.
 

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map id="uan_admin">
+    <title>HPE Cray User Access Node (UAN) Software Administration Guide (S-8033)</title>
+    <topicmeta>
+        <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
+        <data name="pubsnumber" value="S-8033"></data>
+		<data name="edition" value="UAN Software Release 2.3.2"></data>
+    </topicmeta>
+    <topicref href="About_UAN_Administration.md" format="markdown">
+        <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>
+    </topicref>
+    <topicref href="Manage_UAN_Boot_Images.md" format="markdown">
+        <topicref href="operations/Create_UAN_Boot_Images.md" format="markdown"/>
+        <topicref href="operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md" format="markdown"
+        />
+    </topicref>
+    <topicref href="Administrative_Tasks.md" format="markdown">
+        <topicref href="operations/Configure_Interfaces_on_UANs.md" format="markdown"/>
+        <topicref href="operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md"
+            format="markdown"/>
+        <topicref href="operations/Mount_a_New_File_System_on_an_UAN.md" format="markdown"/>
+    </topicref>
+    <topicref href="Advanced_Administrative_Tasks.md" format="markdown">
+        <topicref href="advanced/Customizing_UAN_Images_Manually.md" format="markdown"/>
+    </topicref>
+    <topicref href="Troubleshooting.md" format="markdown">
+        <topicref href="troubleshooting/Troubleshoot_UAN_Boot_Issues.md" format="markdown"/>
+        <topicref href="troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md"
+            format="markdown"/>
+        <topicref href="troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md"
+            format="markdown"/>
+    </topicref>
+    <topicref href="Reference.md" format="markdown">
+        <topicref href="operations/UAN_Ansible_Roles.md" format="markdown"/>
+    </topicref>
+</map>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map id="uan_install">
+    <title>HPE Cray User Access Node (UAN) Software Installation Guide (S-8032)</title>
+        <topicmeta>
+            <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
+            <data name="pubsnumber" value="S-8032"></data>
+			<data name="edition" value="UAN Software Release 2.3.2"></data>
+        </topicmeta>
+    <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
+    <topicref href="installation_prereqs/Hardware_and_Software_Prerequisites.md" format="markdown">
+        <topicref href="installation_prereqs/Prepare_for_UAN_Product_Installation.md"
+            format="markdown"/>
+        <topicref href="installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md"
+            format="markdown"/>
+        <topicref href="installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md" format="markdown"/>
+        <topicref href="installation_prereqs/Configure_the_BIOS_of_a_Gigabyte_UAN.md"
+            format="markdown"/>
+    </topicref>
+    <topicref href="install/Install_the_UAN_Product_Stream.md" format="markdown"/>
+    <topicref href="upgrade/Merge_UAN_Configuration_Data.md" format="markdown"/>
+</map>

--- a/docs/portal/developer-portal/upgrade/Merge_UAN_Configuration_Data.md
+++ b/docs/portal/developer-portal/upgrade/Merge_UAN_Configuration_Data.md
@@ -1,10 +1,8 @@
-## Merge UAN Configuration Data
+# Merge UAN Configuration Data
 
 Perform this procedure to update the UAN product configuration.
 
-Before performing this procedure:
-
-- Perform [Install the UAN Product Stream](../install/Install_the_UAN_Product_Stream.md#install-the-uan-product-stream)
+Before performing this procedure, perform [Install the UAN Product Stream](../install/Install_the_UAN_Product_Stream.md#install-the-uan-product-stream)
 
 In this procedure, an upgrade from UAN 2.0.0 to UAN 2.3.1 is being performed. Administrators should replace the versions seen in this procedure with the versions being upgraded on the system. Additionally, this guide describes upgrading an `integration` branch. Each CFS branch responsible for configuring the various types of Application and UANs should be upgraded. 
 
@@ -15,18 +13,18 @@ In this procedure, an upgrade from UAN 2.0.0 to UAN 2.3.1 is being performed. Ad
     ncn-m001# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
     ```
 
-2. Obtain the URL of UAN configuration management repository in VCS \(the Gitea service\).
+2. Obtain the URL of the UAN configuration management repository in VCS (the Gitea service).
 
     This URL is reported as the value of the `configuration.clone_url` key in the `cray-product-catalog` Kubernetes ConfigMap.
 
-9. Obtain the `crayvcs` password.
+3. Obtain the `crayvcs` password.
 
     ```bash
     ncn-m001# kubectl get secret -n services vcs-user-credentials \
      --template={{.data.vcs_password}} | base64 --decode
     ```
 
-10. Clone the UAN configuration management repository. Replace the hostname reported in the URL obtained in the previous step with `api-gw-service-nmm.local` when cloning the repository.
+4. Clone the UAN configuration management repository. Replace the hostname reported in the URL obtained in the previous step with `api-gw-service-nmm.local` when cloning the repository.
 
     ```bash
     ncn-m001# git clone https://api-gw-service-nmn.local/vcs/cray/uan-config-management.git
@@ -37,7 +35,7 @@ In this procedure, an upgrade from UAN 2.0.0 to UAN 2.3.1 is being performed. Ad
     Already up to date.
     ```
 
-11. Checkout the branch currently used to hold UAN configuration.
+5. Checkout the branch currently used to hold UAN configuration.
 
     The following example assumes that branch is `integration`.
 
@@ -47,19 +45,19 @@ In this procedure, an upgrade from UAN 2.0.0 to UAN 2.3.1 is being performed. Ad
     Your branch is up to date with 'origin/integration'.
     ```
 
-12. Merge the new install branch to the current branch. Write a commit message when prompted.
+6. Merge the new install branch to the current branch. Write a commit message when prompted.
 
     ```bash
     ncn-m001# git merge cray/uan/PRODUCT_VERSION
     ```
 
-13. Push the changes to VCS. Enter the `crayvcs` password when prompted.
+7. Push the changes to VCS. Enter the `crayvcs` password when prompted.
 
     ```bash
     ncn-m001# git push
     ```
 
-14. Retrieve the commit ID from the merge and store it for later use.
+8. Retrieve the commit ID from the merge and store it for later use.
 
     ```bash
     ncn-m001# git rev-parse --verify HEAD
@@ -67,78 +65,80 @@ In this procedure, an upgrade from UAN 2.0.0 to UAN 2.3.1 is being performed. Ad
 
 9. Update any CFS configurations used by the UANs with the commit ID from the previous step.
 
-    a. Download the JSON of the current UAN CFS configuration to a file.
+    1. Download the JSON of the current UAN CFS configuration to a file.
+       
+       The CFS configuration `uan-config-2.0.0` is an example, the site should use the CFS configuration used for the UANs being upgraded.
 
-    ​	The CFS configuration `uan-config-2.0.0` is an example, the site should use the CFS configuration used for the UANs being upgraded.
-
-    ​	This file will be named `uan-config-2.3.1.json` since it will be modified and then used for the updated UAN version.
+       This file will be named `uan-config-2.3.1.json` since it will be modified and then used for the updated UAN version.
 
        ```bash
-           ncn-m001# cray cfs configurations describe uan-config-2.0.0 \
-            --format=json &>uan-config-2.3.1.json
+       ncn-m001# cray cfs configurations describe uan-config-2.0.0 \
+       --format=json &>uan-config-2.3.1.json
        ```
 
-    b. Remove the unneeded lines from the JSON file.
+    2. Remove the unneeded lines from the JSON file.
 
-    ```bash
-    The lines to remove are:
+       The lines to remove are:
     
        - the `lastUpdated` line
        - the last `name` line 
     
-    These must be removed before uploading the modified JSON file back into CFS to update the UAN configuration.
+       These must be removed before uploading the modified JSON file back into CFS to update the UAN configuration.
     
-    ncn-m001# cat uan-config-2.3.1.json
-    {
-      "lastUpdated": "2021-03-27T02:32:10Z",      
-      "layers": [
+       ```bash
+       ncn-m001# cat uan-config-2.3.1.json
+       {
+         "lastUpdated": "2021-03-27T02:32:10Z",      
+         "layers": [
+           {
+             "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/uan-config-management.git",
+             "commit": "aa5ce7d5975950ec02493d59efb89f6fc69d67f1",
+             "name": "uan-integration-2.0.0",
+             "playbook": "site.yml"
+           },
+         "name": "uan-config-2.0.0"            
+       }
+       ```
+
+    3. Replace the `commit` value in the JSON file with the commit ID obtained with `git rev-parse --verify HEAD`.
+
+       The `name` value after the `commit` line may also be updated to match the new UAN product version, if desired. This is not necessary as CFS does not use this value for the configuration name.
+       
+       ```bash
+       {
+        "layers": [
         {
-          "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/uan-config-management.git",
-          "commit": "aa5ce7d5975950ec02493d59efb89f6fc69d67f1",
-          "name": "uan-integration-2.0.0",
-          "playbook": "site.yml"
-        },
-      "name": "uan-config-2.0.0"            
-    }
-    ```
+        "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/uan-configmanagement.git",
+        "commit": "aa5ce7d5975950ec02493d59efb89f6fc69d67f1",
+        "name": "uan-integration-2.0.0",
+        "playbook": "site.yml"
+        }
+        ]
+       }
+       ```
 
-    c. Replace the `commit` value in the JSON file with the commit ID obtained with `git rev-parse --verify HEAD`.
-
-    ```bash
-    The name value after the commit line may also be updated to match the new UAN product version, if desired. This is not necessary as CFS does not use this value for the configuration name.
-    
-    {
-     "layers": [
-     {
-     "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/uan-configmanagement.git",
-     "commit": "aa5ce7d5975950ec02493d59efb89f6fc69d67f1",
-     "name": "uan-integration-2.0.0",
-     "playbook": "site.yml"
-     }
-     ]
-    }
-    ```
-
-    d. Create a new UAN CFS configuration with the updated JSON file.
+    4. Create a new UAN CFS configuration with the updated JSON file.
 
        The following example uses `uan-config-2.3.1` for the name of the new CFS configuration, to match the JSON file name.
 
-    ```bash
-    ncn-m001# cray cfs configurations update uan-config-2.3.1 \
-     --file uan-config-2.3.1.json
-    ```
+       ```bash
+       ncn-m001# cray cfs configurations update uan-config-2.3.1 \
+       --file uan-config-2.3.1.json
+       ```
 
-    e. Tell CFS to apply the new configuration to UANs by repeating the following command for each UAN. Replace UAN\_XNAME in the command below with the name of a different UAN each time the command is run.
+    5. Tell CFS to apply the new configuration to UANs by repeating the following command for each UAN. Replace `UAN_XNAME` in the command below with the name of a different UAN each time the command is run.
 
         ```bash
         ncn-m001# cray cfs components update --desired-config uan-config-2.0.1 \
         --enabled true --format json UAN_XNAME
         ```
 
-16. Finish the typescript file started at the beginning of this procedure.
+10. Finish the typescript file started at the beginning of this procedure.
 
     ```bash
     ncn-m001# exit
     ```
 
-17. Perform [Build a New UAN Image Using the COS Recipe](../operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md) and [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md) to upgrade the boot images and perform CFS image customization for the UAN images.
+11. Deploy the updated UAN product software to the User Access Nodes. 
+    
+    Continue with "Build a New UAN Image Using the COS Recipe" and "Create UAN Boot Images" in the publication _HPE Cray User Access Node (UAN) Software Administration Guide_ to upgrade the boot images and perform CFS image customization for the UAN images.

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -1,14 +1,14 @@
-## Notable Changes
+# Notable Changes
 
 The following guide describes changes included in a particular UAN version that may be of note during an install or upgrade.
 
-When an upgrade is being performed, please review the notable changes for **all** of the UAN versions up to the version being installed. If a particular version does not appear in this guide, it may have only had minor changes. For a full account of the changes involved in a release, consult the [Change Log](../ChangeLog.md)
+When an upgrade is being performed, please review the notable changes for **all** of the UAN versions up to the version being installed. If a particular version does not appear in this guide, it may have only had minor changes. For a full account of the changes involved in a release, consult the ChangeLog.md file at the root of the UAN product repository.
 
-#### UAN 2.2
+## UAN 2.2
 
 * UAN 2.2 was an internal release and was not made generally available.
 
-#### UAN 2.3.1
+## UAN 2.3.1
 
 * UAN 2.3 no longer ships a default recipe or image. To build a UAN image, administrators should select a COS recipe to build as the base of their UAN and Application Nodes.
 * The role `uan_packages` will now install the rpms needed by UAN and Application Nodes
@@ -16,7 +16,7 @@ When an upgrade is being performed, please review the notable changes for **all*
   * `uan_disable_gpg_check: yes` must be set if CSM is earlier than 1.2
   * `uan_disable_gpg_check: no` should be set if CSM is 1.2 or greater
 
-#### UAN 2.3.2
+## UAN 2.3.2
 
 * UAN 2.3.2 adds support for a Bifurcated Customer Access Network \(BiCAN\) and the ability to specify a default route other than the CAN or CHN when they are selected.  
   * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customers user network.  By default, a direct connection is selected as it was in previous releases.  The choice of `CAN` or `CHN` must match the overall system implementation.

--- a/docs/portal/developer-portal/upgrade/Upgrades.md
+++ b/docs/portal/developer-portal/upgrade/Upgrades.md
@@ -1,4 +1,4 @@
-## Upgrades
+# Upgrades
 
 Performing an upgrade of UAN from one version to the next follows the same general process as a fresh install. Some considerations may need to be made  when merging the existing CFS configuration with the latest CFS configuration provided by the release.
 


### PR DESCRIPTION
## Summary and Scope

Changes to enable direct publishing of the docs to HPESC using DITA Open Toolkit (DITA-OT).

## Issues and Related PRs

* Resolves [TPCCMS-230](issue link)
* These changes were already made to the release/uan-2.3 branch.

## Testing

These changes were tested by publishing to the ITG test portal and review by Alan.

### Tested on:

  * ITG portal

## Risks and Mitigations

* Header levels changed in all Markdown files since DITA-OT requires that they start at Level 1.
* The UAN Ansible Roles file also had many headings changed to definition lists. This may impact the Hugo build scripts.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

