### PR TITLE
Chn on compute

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Change documentation to reflect streamlined selection of CAN/CHN
+- Change documentation to reflect uan_interfaces can configure compute default route
 - Change documentation to use sat bootprep
 - Updates to vendor directory for generating and installing releases
 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 1.7.0
+    - 1.6.0
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 0.5.0
+    - 1.7.0
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/docs/portal/developer-portal/operations/About_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/About_UAN_Configuration.md
@@ -13,6 +13,8 @@ The UAN-specific roles involved in post-boot UAN node configuration are:
 - `uan_disk_config`: this role configures the last disk found on the UAN that is smaller than 1TB, by default. That disk will be formatted with a scratch and swap partition mounted at /scratch and /swap, respectively. Each partition is 50% of the disk.
 - `uan_packages`: this role installs any RPM packages listed in the uan-config-management repo.
 - `uan_interfaces`: this role configures the UAN node networking. By default, this role does not configure a default route or the Customer Access Network \(CAN or CHN\) connection for the HPE Cray EX supercomputer. If CAN or CHN is enabled, the default route will be on the CAN or CHN. Otherwise, a default route must be set up in the customer interfaces definitions. Without the CAN or CHN, there will not be an external connection to the customer site network unless one is defined in the customer interfaces. See [Configure Interfaces on UANs](Configure_Interfaces_on_UANs.md).
+
+  ***NOTE:*** If a UAN layer is used in the Compute node CFS configuration, the `uan_interfaces` role will configure the default route on Compute nodes to be on the HSN, if the BICAN System Default Route is set to `CHN`.
 - `uan_motd`: this role Provides a default message of the day that can be customized by the administrator.
 - `uan_ldap`: this optional role configures the connection to LDAP servers. To disable this role, the administrator must set 'uan_ldap_setup:no' in the 'uan-config-management' VCS repository.
 

--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -13,7 +13,7 @@ By default, a direct connection to the sites user network is assumed and the Adm
 
 Network configuration settings are defined in the `uan-config-management` VCS repo under the `group_vars/ROLE_SUBROLE/` or `host_vars/XNAME/` directories, where `ROLE_SUBROLE` must be replaced by the role and subrole assigned for the node in HSM, and `XNAME` with the xname of the node. Values under `group_vars/ROLE_SUBROLE/` apply to all nodes with the given role and subrole.  Values under the `host_vars/XNAME/` apply to the specific node with the xname and will override any values set in `group_vars/ROLE_SUBROLE/`.  A yaml file is used by the Configuration Framwork Service \(CFS\).  The examples in this procedure use `customer_net.yml`, but any filename may be used.  Admins must create this yaml file and use the variables described in this procedure.
 
-If the HPE Cray EX CAN or CHN is required, set the `uan_user_access_cfg` variable to `CAN` or `CHN` in the yaml file.
+If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `yes` in the yaml file.  The UAN will be configured to use the CAN or CHN based on what the BICAN System Default Route is set to in SLS.
 
 1. Obtain the password for the `crayvcs` user.
 
@@ -41,12 +41,11 @@ If the HPE Cray EX CAN or CHN is required, set the `uan_user_access_cfg` variabl
     To set up CAN or CHN:
 
     ```bash
-    ## uan_user_access_cfg
-    # Set uan_user_access_cfg to 'CAN' if the site will
-    # use the Shasta CAN network or to 'CHN' if the site
-    # will use the Shasta CHN network for user access.
-    # By default, uan_user_access_cfg is set to 'DIRECT'.
-    uan_user_access_cfg: CHN
+    ## uan_can_setup
+    # Set uan_can_setup to 'yes' if the site will
+    # use the Shasta CAN or CHN network for user access.
+    # By default, uan_can_setup is set to 'no'.
+    uan_can_setup: yes
     ```
 
     To allow a custom default route when CAN or CHN is selected:

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -111,6 +111,8 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 
     Consult the individual Ansible role `README.md` files in the uan-config-management repository roles directory to configure individual role variables. Roles prefixed with `uan_` are specific to UAN configuration and include network interfaces, disk, LDAP, software packages, and message of the day roles.
 
+    ***NOTE:*** Admins ***must*** ensure the `uan_can_setup` variable is set to the correct value for the site.  This variable controls how the nodes are configured for user access. When `uan_can_setup` is `yes`, user access is over the `CAN` or `CHN`, based on the BICAN System Default Route setting in SLS.  When `uan_can_setup` is `no`, the Admin must configure the user access interface and default route. See [Configure Interfaces on UANs](Configure_interfaces_on_UANs.md)
+
     **Warning:** Never place sensitive information such as passwords in the git repository.
 
     The following example shows how to add a `vars.yml` file containing site-specific configuration values to the `Application_UAN` group variable location.

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -111,16 +111,6 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 
     Consult the individual Ansible role `README.md` files in the uan-config-management repository roles directory to configure individual role variables. Roles prefixed with `uan_` are specific to UAN configuration and include network interfaces, disk, LDAP, software packages, and message of the day roles.
 
-    ***NOTE:*** Admins ***must*** ensure the `uan_user_access_cfg` variable is set to the correct value for the site.  This variable controls how the nodes are configured for user access.  The options are:
-    * `DIRECT` \(default setting\): the site will directly connect to the nodes to their site user network.
-      * Admins ***must*** define the interface and default route using `customer_uan_interfaces` and `customer_uan_routes` variables or no default route will be set.
-    * `CAN`: the site will use the Cray EX Customer Access Network \(CAN\).
-      * Default route is automatically set over the `CAN`.
-    * `CHN`: the site will use the Cray EX Customer High Speed Network \(CHN\).
-      * Default route is automatically set over the `CHN`.
-
-    See [Configure Interfaces on UANs](Configure_Interfaces_on_UANs.md) for details on user access configuration.
-
     **Warning:** Never place sensitive information such as passwords in the git repository.
 
     The following example shows how to add a `vars.yml` file containing site-specific configuration values to the `Application_UAN` group variable location.

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -164,75 +164,32 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-`uan_can_setup` (Deprecated)
+### `uan_can_setup`
 
-: This variable is deprecated and `uan_user_access_cfg` should be used.
+`uan_can_setup` is a boolean variable controlling the configuration of user
+access to UAN nodes.  When true, user access is configured over either the
+Customer Access Network (CAN) or Customer High Speed Network (CHN), depending on which is configured on the system.
 
-: `uan_can_setup` is a boolean variable controlling the configuration of user
-access to UAN nodes over the Customer Access Network (CAN).  The CAN is a VLAN
-on the Node Management Network (NMN).
+When `uan_can_setup` is false, user access over the CAN or CHN is not configured
+on the UAN nodes and no default route is configured.  The Admin must then specify
+the default route in `customer_uan_routes`.
 
-: When `uan_can_setup` has a true value, the default route is set to be on the CAN
-unless `uan_customer_default_route` has a true value.  If `uan_can_setup` has a
-false value, user access over the CAN is not configured on the UAN nodes and no
-default route configured.  The admin must then specify the default route in
-`customer_uan_routes`.
+The default value of `uan_can_setup` is `no`.
 
-: The default value of `uan_can_setup` is `no`.
+```yaml
+uan_can_setup: no
+```
 
-  Example:
+### `uan_customer_default_route`
 
-  ```yaml
-  uan_can_setup: no
-  ```
+`uan_customer_default_route` is a boolean variable that allows the default route
+to be set by the `customer_uan_routes` data when `uan_can_setup` is true.
 
-`uan_user_access_cfg`
+By default, no default route is setup unless `uan_can_setup` is true, which sets the default route to the CAN or CHN.
 
-: `uan_user_access_cfg` defines the way users access the UAN nodes.  UANs may be
-configured to use a VLAN over the Node Management Network (CAN), a subnet on the
-High Speed Network (CHN), or a direct connection to a site network (DIRECT).
-
-: Valid values for `uan_user_access_cfg` are `"CAN"`, `"CHN"`, or `"DIRECT"`.  The
-default value is `"DIRECT"`.  With `uan_user_access_cfg: "DIRECT"`, the admin
-must define the interface and and routing to use.  See `customer_uan_interfaces`
-and `customer_uan_routes`.  With `uan_user_access_cfg: "CAN"` or
-`uan_user_access_cfg: "CHN"`, the default route will be set to the CAN or CHN,
-respectively, unless `uan_customer_default_route` has a true value.  Then the
-admin must define a default route in `customer_uan_routes`.
-
-  Example:
-
-  ```yaml
-  uan_user_access_cfg: "CHN"
-  ```
-
-`uan_customer_default_route`
-
-: `uan_customer_default_route` is a boolean variable that allows the default route
-to be set by the `customer_uan_routes` data when `uan_user_access_cfg` is set to
-CAN or CHN.
-
-: By default, no default route is setup unless `uan_user_access_cfg` is set to
-either `"CAN"` or `"CHN"` which sets the default route to the CAN or CHN,
-respectively.
-
-  Example:
-
-  ```yaml
-  uan_customer_default_route: no
-  ```
-
-`valid_uan_user_access_cfgs`
-
-: `valid_uan_user_access_cfgs` is a list of valid values for `uan_user_access_cfg`.
-This value should not be changed.
-
-  ```yaml
-  valid_uan_user_access_cfgs:
-    - "DIRECT"
-    - "CAN"
-    - "CHN"
-  ```
+```yaml
+uan_customer_default_route: no
+```
 
 `sls_nmn_name`
 

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -19,9 +19,8 @@ When an upgrade is being performed, please review the notable changes for **all*
 ## UAN 2.4.0
 
 * UAN 2.4.0 adds support for a Bifurcated Customer Access Network \(BiCAN\) and the ability to specify a default route other than the CAN or CHN when they are selected.  
-  * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customers user network.  By default, a direct connection is selected as it was in previous releases.  The choice of `CAN` or `CHN` must match the overall system implementation.
-    * `uan_user_access_cfg` selects the customer access network implementation to use and replaces `uan_can_setup`.  Valid values are `CAN`, `CHN`, or `DIRECT`.  Default is `DIRECT`.
-    * `uan_can_setup` is now deprecated.  If present and true, it resolves to `uan_user_access_cfg: CAN`.
-  * Application nodes may now set a default route other than the CAN or CHN default route when CAN or CHN are selected.
-    * `uan_customer_default_route: true` will allow a customer defined default route to be set using the `customer_uan_routes` structure when `uan_user_access_cfg` is set to `CAN` or `CHN`.
+  * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customers user network.  By default, a direct connection is selected as it was in previous releases.  
+    * `uan_can_setup`, when set to `yes`, selects the customer access network implementation based on the setting of the BICAN System Default Route in SLS.
+    * Application nodes may now set a default route other than the CAN or CHN default route when `uan_can_setup: yes`.
+    * `uan_customer_default_route: true` will allow a customer defined default route to be set using the `customer_uan_routes` structure when `uan_can_setup` is set to `yes`.
 * `sat bootprep` is now used in the documentation to streamline the IMS, CFS, and BOS commands to create and customize images and creating sessiontemplates.

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.4.0
+    - 1.7.0

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.7.0
+    - 1.6.0

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.4.0
+    version: 1.7.0
     namespace: services
     values:
       cray-import-config:

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.7.0
+    version: 1.6.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
Manifest and doc changes for CHN selection and compute default route change

## Summary and Scope

This PR updates the docs to reflect the new streamlined method of selecting CAN or CHN for user access setup.  It also documents that uan_interfaces can configure the default route on computes when CHN is the BICAN System Default Route.

## Issues and Related PRs

* Resolves [CASMUSER-2995](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2995)
* Resolves [CASMUSER-2982](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2982)

## Testing

### Tested on:

  * `hela`

### Test description:

Code was run on hela to verify UAN and Compute configuration was done as expected.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

