### PR TITLE
Casmuser 3021

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.4.2] - 2022-06-06
 - Reverse the order of CHN Gateway conditions to avoid undefined references in ansible
 - Add where clause to Mountain NMN gateway play to avoid undefined reference on non-Mountain systems
+- Update zypper repo to UAN-2.4 version
 
 ## [2.4.1] - 2022-05-24
 - Increase short LDAP timeout

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2022-06-06
+- Reverse the order of CHN Gateway conditions to avoid undefined references in ansible
+- Add where clause to Mountain NMN gateway play to avoid undefined reference on non-Mountain systems
+
 ## [2.4.1] - 2022-05-24
 - Increase short LDAP timeout
 - CHN fixes for compute nodes leveraging an IP in SLS

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 1.8.1
+    - 1.8.2
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 1.8.2
+    - 1.8.3
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -34,3 +34,7 @@ When an upgrade is being performed, please review the notable changes for **all*
     * Fully configured HSN
     * SLS has IP assignments for compute nodes on hsn0
 * Updates to GPU roles to match COS 2.3
+
+## UAN 2.4.2
+
+* There is a known issue with the version of GPU support included in the UAN CFS repo. The result is that both AMD and Nvidia SDKs are not able to be projected at the same time. Until this is resolved in a later release, modify the site.yml in the UAN CFS repo to only include either amd or nvidia.

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.8.1
+    - 1.8.2

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.8.2
+    - 1.8.3

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.8.2
+    version: 1.8.3
     namespace: services
     values:
       cray-import-config:

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.8.1
+    version: 1.8.2
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Fix problems seen on vale Raspberry install (2.4.1):
* Problems with NMN setup on non-Mountain hardware
* Problems with the wickedd logic on CAN based systems
* Fix version of the UAN zypper repo
* Document GPU workaround for Raspberry

Backward compatible bugfix

## Issues and Related PRs

* Resolves [CASMUSER-3021](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3021)

## Testing

### Tested on:

  * vale
  * hermod
  * hela
  * gamora

### Test description:

Installed, built images, booted and ran CFS on vale. Installed and built images on hela, gamora, and hermod.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

This change has low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
