### PR TITLE
Fix CAN and CHN routing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.3] - 2022-06-24
+- Add routing to CHN and CAN MetalLB
+- Prevent loss of existing routes
+
 ## [2.4.2] - 2022-06-06
 - Reverse the order of CHN Gateway conditions to avoid undefined references in ansible
 - Add where clause to Mountain NMN gateway play to avoid undefined reference on non-Mountain systems

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 1.8.3
+    - 1.8.4
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.8.3
+    - 1.8.4

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.8.3
+    version: 1.8.4
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Fix UAN routing for CHN and CAN.  Added CHN and CAN MetalLB routes regardless of whether ifroute files exist or not.  Also stopped stomping on exist HSN routes.

## Issues and Related PRs

* CASMNET-1579
* CASMTRIAGE-3596

## Testing

### Tested on:

  * `hela`
  * `vale`

### Test description:

Ran CFS with updated uan_interfaces role and also rebooted nodes, then verified routing.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

