### PR TITLE
CASMNET-1636: Include new uan_hardening role

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.4.3] - 2022-06-24
 - Add routing to CHN and CAN MetalLB
 - Prevent loss of existing routes
+- Add new uan_hardening role to block SSH traffic to NCNs
 
 ## [2.4.2] - 2022-06-06
 - Reverse the order of CHN Gateway conditions to avoid undefined references in ansible

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 1.8.4
+    - 1.8.5
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -38,3 +38,7 @@ When an upgrade is being performed, please review the notable changes for **all*
 ## UAN 2.4.2
 
 * There is a known issue with the version of GPU support included in the UAN CFS repo. The result is that both AMD and Nvidia SDKs are not able to be projected at the same time. Until this is resolved in a later release, modify the site.yml in the UAN CFS repo to only include either amd or nvidia.
+
+## UAN 2.4.3
+
+* A new CFS role, `uan_hardening` adds iptables rules that will block SSH traffic to NCNs. See the README.md in the uan_hardening role for more information.

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.8.4
+    - 1.8.5

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.8.4
+    version: 1.8.5
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Add the new role `uan_hardening`

## Issues and Related PRs

* Resolves CASMNET-1636

## Testing

  * `vale`

### Test description:

@alexanderkingh tested the new role on vale. Iptables rules now block SSH traffic from a UAN

Verified could still run a slurm job and saw PE was available
```
uan01:~ # iptables -L -n --line-numbers
Chain INPUT (policy ACCEPT)
num  target     prot opt source               destination

Chain FORWARD (policy ACCEPT)
num  target     prot opt source               destination

Chain OUTPUT (policy ACCEPT)
num  target     prot opt source               destination
1    DROP       tcp  --  0.0.0.0/0            10.92.100.0/24       tcp dpt:22
2    DROP       tcp  --  0.0.0.0/0            10.252.0.0/17        tcp dpt:22

alanm@uan01:/lus/fakelus> srun hostname
nid000001
alanm@uan01:/lus/fakelus> id alanm
uid=29289(alanm) gid=12790(employee) groups=12790(employee),1013(osgp),12534(craypri),26050(docker),12584(craydev),8001(intel_rsnda),1113(udump)
alanm@uan01:/lus/fakelus> module list
Currently Loaded Modulefiles:
  1) craype-x86-rome                        4) perftools-base/22.05.0                 7) craype/2.7.15                         10) cray-libsci/21.08.1.2
  2) libfabric/1.11.0.4.124                 5) xpmem/2.4.4-2.3_2.7__gff0e1d9.shasta   8) cray-dsmml/0.2.2                      11) PrgEnv-cray/8.3.3
  3) craype-network-ofi                     6) cce/14.0.0                             9) cray-mpich/8.1.16
```

## Risks and Mitigations

If there are any problems with the new roles, they may be disabled with:
```
disable_ssh_out_uan_to_nmn_lb: no
disable_ssh_out_nmn_to_management_ncns: no
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

