### PR TITLE
Enable PSI via the kernel parameters in sat bootprep

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-07-15
+## [Unreleased] - 2022-07-26
 - Add support for uan_hardening role on computes
+- Enable Pressure Stall Information (PSI) in kernels >= 4.20
 
 ## [2.4.3] - 2022-06-24
 - Add routing to CHN and CAN MetalLB

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -216,7 +216,7 @@ session_templates:
   bos_parameters:
     boot_sets:
       uan:
-        kernel_parameters: spire_join_token=${SPIRE_JOIN_TOKEN}
+        kernel_parameters: "spire_join_token=${SPIRE_JOIN_TOKEN} psi=1"
         node_roles_groups:
         - Application_UAN
 ```


### PR DESCRIPTION
## Summary and Scope

This PR adds the **psi=1** kernel parameter to the kernel parameters in the **sat bootprep** configuration file which enables the Pressure Stall Information feature in the Linux kernel.

## Issues and Related PRs

* Resolves ([CASMUSER-2941](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2941))

## Testing

### Tested on:

  * `rocket` for UANs with a stock kernel
  * `hela` for UANs with a COS kernel

### Test description:

Tested by adding the **psi=1** kernel parameter to the BSS information for stock kernel UANs and to the BOS session template (via sat bootprep) and rebooting the UANs.  Examined the files in /proc/pressure to verify pressure stall info was being collected.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

