### PR TITLE
Added WAR for CASMUSER-3058

### DIFF
--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -98,9 +98,7 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 
 8. Create a branch using the imported branch from the installation to customize the UAN image.
 
-    This will be reported in the `cray-product-catalog` Kubernetes ConfigMap in the `configuration.import_branch` key under the UAN section. The format is cray/uan/PRODUCT\_VERSION. In this guide, an `integration` branch is used for examples, but the name can be any valid git branch name.
-
-    Modifying the cray/uan/PRODUCT\_VERSION branch that was created by the UAN product installation is not allowed by default.
+    This will be reported in the `cray-product-catalog` Kubernetes ConfigMap in the `configuration.import_branch` key under the UAN section. In this guide, an `integration` branch is used for examples, but the name can be any valid git branch name.
 
     ```bash
     ncn-m001# git checkout -b integration origin/integration

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -103,12 +103,40 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
     Modifying the cray/uan/PRODUCT\_VERSION branch that was created by the UAN product installation is not allowed by default.
 
     ```bash
-    ncn-m001# git checkout -b integration && git merge cray/uan/PRODUCT_VERSION
+    ncn-m001# git checkout -b integration origin/integration
     Switched to a new branch 'integration'
     Already up to date.
     ```
 
-9. Apply any site-specific customizations and modifications to the Ansible configuration for the UAN nodes and commit the changes.
+9. Enable kernel watchdog modules by applying the following diff to `roles/kdump/files/kdump_initrd.sh`:
+
+    ```
+    # diff -c kdump_initrd.sh.orig kdump_initrd.sh
+    *** kdump_initrd.sh.orig	2022-08-08 16:15:00.324352377 +0000
+    --- kdump_initrd.sh	2022-07-26 15:52:39.935998380 +0000
+    ***************
+    *** 39,44 ****
+    --- 39,45 ----
+      terminfo \
+      udev-rules \
+      url-lib \
+   + watchdog-modules \
+      "
+
+    # Add network-legacy for SP2
+    ***************
+    *** 92,97 ****
+    --- 93,99 ----
+
+      for n in $exclude_list
+      do
+    +     [[ -d /lib/modules/${premium_version}/$n ]] || continue
+          for x in $(find /lib/modules/${premium_version}/$n -name "*.ko*")
+          do
+              v=${x##/*/}   
+    ```
+
+10. Apply any site-specific customizations and modifications to the Ansible configuration for the UAN nodes and commit the changes.
 
     The default Ansible play to configure UAN nodes is `site.yml` in the base of the `uan-config-management` repository. The roles that are executed in this play allow for custom  configuration as required for the system.
 

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -98,10 +98,10 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 
 8. Create a branch using the imported branch from the installation to customize the UAN image.
 
-    This will be reported in the `cray-product-catalog` Kubernetes ConfigMap in the `configuration.import_branch` key under the UAN section. In this guide, an `integration` branch is used for examples, but the name can be any valid git branch name.
+    This will be reported in the `cray-product-catalog` Kubernetes ConfigMap in the `configuration.import_branch` key under the UAN section. The format is cray/uan/PRODUCT\_VERSION. In this guide, an `integration` branch is used for examples, but the name can be any valid git branch name.
 
     ```bash
-    ncn-m001# git checkout -b integration origin/integration
+    ncn-m001# git checkout -b integration && git merge cray/uan/PRODUCT_VERSION
     Switched to a new branch 'integration'
     Already up to date.
     ```


### PR DESCRIPTION
## Summary and Scope

Changed one step and added another one due to CASMUSER-3058, resulting from SKERN-6718 on COS. This PR updates UAN release 2.3. Another PR will be made for updating UAN 2.4, which requires fewer changes.

Docs-only change.

## Issues and Related PRs

[CASMUSER-3058](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3058)
[SKERN-6718](https://jira-pro.its.hpecorp.net:8443/browse/SKERN-6718)

## Testing

Tested via local docs builds made on WSL2/Ubuntu environment. Verified formatting on ITG test portal.


## Risks and Mitigations

No known risks.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [*] License file intact
- [*] Target branch correct
- [ ] CHANGELOG.md updated
- [*] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

