### PR TITLE
Add procedure for repurposing compute as uan

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-07-15
+## [Unreleased] - 2022-08-09
+- Add documentation for repurposing compute nodes as UANs
 
 ## [2.5.0] - 2022-07-29
 - Add support for uan_hardening role on computes

--- a/docs/portal/developer-portal/advanced/Repurposing_Compute_as_UAN.md
+++ b/docs/portal/developer-portal/advanced/Repurposing_Compute_as_UAN.md
@@ -1,0 +1,109 @@
+# Repurposing a Compute Node as a UAN
+
+This section describes how to repurpose a compute node to be used as a User Access Node (UAN).  This is typically done when the processor type of the compute node is not yet available in a UAN server.
+
+## Overview
+
+The following steps outline the process of repurposing a compute node to be used as a UAN.
+
+  1. Verify the System Default Route is set to `CHN`.
+    
+  1. Change the role of the compute node in the Hardware State Manager from `Compute` to `Application` and set the sub-role to `UAN`.
+
+  1. Ensure that IPs on the CHN exist for the computes nodes in SLS.
+
+  1. Boot the repurposed compute node as a UAN.
+
+  1. Verify the repurposed compute node functions as a UAN.
+
+## Prerequisites
+
+There are no changes needed in hardware, network cabling, or UEFI/BIOS/BMC configuration to repurpose a compute node for use as a UAN.  However, compute nodes do not have the necessary network interface cards to support user access over the Customer Access Network (CAN). Additionally, the network configuration of Mountain Cabinets do not support the CAN network. Therefore, repurposing a compute node as a UAN requires the system to be configured to use the Customer High-Speed Network (CHN) and that the compute nodes have a CHN IP address in SLS.
+
+* The SLS Networks setting for the `SystemDefaultRoute` must be `CHN`
+* The repurposed compute nodes must have CHN IP addresses in SLS
+
+## Procedure
+
+Perform the following steps to repurpose a compute node for use as a UAN.
+
+1. Log in to the master node `ncn-m001`. All commands in this procedure are run from the master node.
+
+1. Verify the system is configured to use the `CHN` as the System Default Route. If the `SystemDefaultRoute` is not `CHN`, the compute nodes may not be repurposed as UAN.
+
+    ```bash
+    ncn-m001# cray sls networks describe BICAN  --format json | jq -r '.ExtraProperties.SystemDefaultRoute'
+    ```
+
+1. Verify a CHN IP address exists in SLS for each repurposed compute node. Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node. The compute node must have a CHN IP address in SLS or it cannot be repurposed as a UAN.  See `Add Compute IP addresses to CHN SLS data` section of the Cray System Management documentation for information on adding compute nodes to the CHN.
+
+    ```bash
+    ncn-m001# cray sls networks describe CHN | grep -A 2 <XNAME>
+    ```
+
+1. Change the role and sub-role in HSM of the compute node(s) being repurposed as UANs to `Application` and `UAN`, respectively.  Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node.
+
+    ```bash
+    ncn-m001# cray hsm state components role update --role Application --sub-role UAN <XNAME>
+    ```
+
+1. Verify the role and sub-role in HSM of the repurposed compute node(s) has been changed to 'Application` and 'UAN`, respectively.  Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node.
+
+    ```bash
+    ncn-m001# cray hsm state components describe <XNAME>
+    ```
+
+1. Run the BOS session template used to boot the UAN nodes. See [Boot UAN Nodes](../operations/Boot_UANs.md) for more information on booting UAN nodes with BOS.  Replace `<UAN_SESSIONTEMPLATE>` with the name of the BOS session template used to boot the UAN nodes.
+
+    ```bash
+    ncn-m001# cray bos session create --template-uuid <UAN_SESSIONTEMPLATE> --operation reboot
+    ```
+
+## Verification as a UAN
+
+Once the repurposed compute node is booted as a UAN, the following steps will verify it is configured as a UAN. These steps may vary dependent upon how the site has configured the UAN nodes.
+
+### Basic UAN Configuration Checks
+
+1. Login to the repurposed compute node from the master node `ncn-m001` as the root user.
+
+1. Verify that the `hsn0` interface has the CHN IP address assigned to it in SLS.
+
+    ```bash
+    uan# ip a | grep hsn0
+    ```
+
+1. Verify the default route is via `hsn0`
+
+   ```bash
+   uan# ip r | grep default
+   ```
+
+1. Verify that all site UAN filesystems are mounted.
+
+### Common UAN Configuration Checks
+
+1. If LDAP is used for user authentication, verify the LDAP service is reachable.
+
+    ```bash
+    uan# ping <ldap_service_ip>
+    ```
+
+1. If SLURM is used, test `sinfo` and `srun` commands.  This example `srun` command should return the hostname of 4 compute nodes.
+
+    ```bash
+    uan# sinfo
+
+    uan# srun -N4 hostname
+    ```
+### Verify Users can Login
+
+1. Login to the repurposed compute node as an authorized non-root user from any host that should have UAN access.
+
+1. If SLURM is used, test `sinfo` and `srun` commands.  This example `srun` command should return the hostname of 4 compute nodes.
+
+    ```bash
+    uan# sinfo
+
+    uan# srun -N4 hostname
+    ```

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -24,6 +24,8 @@
     </topicref>
     <topicref href="Advanced_Administrative_Tasks.md" format="markdown">
         <topicref href="advanced/Customizing_UAN_Images_Manually.md" format="markdown"/>
+        <topicref href="advanced/Repurposing_Compute_as_UAN.md" format="markdown"/>
+        <topicref href="advanced/Enabling_CAN_CHN" format="markdown"/>
     </topicref>
     <topicref href="Troubleshooting.md" format="markdown">
         <topicref href="troubleshooting/Troubleshoot_UAN_Boot_Issues.md" format="markdown"/>


### PR DESCRIPTION
## Summary and Scope

This PR adds a procedure for repurposing compute nodes as UANs.

## Issues and Related PRs

* Resolves [CASMUSER-3053](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3053)

## Testing

### Tested on:

  * `hela`

### Test description:

This procedure was tested on hela repurposing one compute node as a UAN.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

