### PR TITLE
Casmuser 3054 - Add repurposed computes to UAN test plan

### DIFF
--- a/docs/portal/developer-portal/test-plan/test-plan.md
+++ b/docs/portal/developer-portal/test-plan/test-plan.md
@@ -1,6 +1,6 @@
-# Test Plan for User Access Node (UAN)
+# Test Plan for User Access Node (UAN) and Repurposed Compute Node as UAN
 
-The following is the test plan for the User Access Node (UAN).  The tests are grouped in three categories:
+The following is the test plan for the User Access Node (UAN) or a Compute Node that has been repurposed to function as a UAN.  The tests are grouped in three categories:
 - Unit tests
 - Integration tests
 - Functional tests
@@ -29,11 +29,12 @@ The following integration tests verify that the UAN software interacts correctly
 
 ## Functional Tests
 
-With a fully configured Shasta system, the following functional tests determines that a UAN is able to perform its intended capabilities.
+With a fully configured Shasta system, the following functional tests determines that a UAN is able to perform its intended capabilities. These tests apply to both native UANs and Compute Nodes which have been repurposed as UANs.
 
 | Summary                      | Description                                                  | Automated | Notes                            |
 | ---------------------------- | ------------------------------------------------------------ | --------- | -------------------------------- |
 | User Authentication          | Verify a user is able to ssh to the UAN using LDAP authentication. | no        | `ssh user@uan`                   |
 | Job launch                   | Verify a user is able to submit a basic job.                 | no        | `srun hostname` |
 | Verify CPE                   | Verify the Cray Programming Environment is available         | no        | `module list`                    |
-| Verify GPU functionality     | Run the test suite if GPUs are configured                    | yes       | `/opt/cray/uan/tests/validate-gpu.sh <nvidia|amd>` |
+| Verify GPU functionality     | Run the test suite if GPUs are configured                    | yes       | `/opt/cray/uan/tests/validate-gpu.sh <nvidia\|amd>` |
+| Verify CAN or CHN Configuration | Inspect the network interfaces and default routes used for CAN or CHN | no | <ul><li> For systems running CAN, there must be a `can0` interface present and the default route should be over that device.</li><li>For systems running CHN (including Compute Nodes repurposed as UANs), the `hsn0` interface must have a CHN IP in addition to the HSN IP and the default route should be over the `hsn0` device.</li></ul> |


### PR DESCRIPTION
## Summary and Scope

This PR adds repurposed compute nodes to the UAN test plan.

## Issues and Related PRs

* Resolves [CASMUSER-3054](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3054)

## Testing

### Tested on:

  * Doc change only
 
### Test description:

Documentation change only.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

