### PR TITLE
CASMUSER-3059: Add SKERN-6718 WAR for kdump

### DIFF
--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -105,7 +105,24 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
     Already up to date.
     ```
 
-9. Apply any site-specific customizations and modifications to the Ansible configuration for the UAN nodes and commit the changes.
+9. Enable kernel watchdog modules by applying the following diff to `roles/kdump/files/kdump_initrd.sh`:
+
+   ```
+   # diff -c kdump_initrd.sh.orig kdump_initrd.sh
+   *** kdump_initrd.sh.orig	2022-08-08 16:17:14.876239045 +0000
+   --- kdump_initrd.sh	2022-08-05 21:42:58.504182223 +0000
+   ***************
+   *** 39,44 ****
+   --- 39,45 ----
+     terminfo \
+     udev-rules \
+     url-lib \
+   + watchdog-modules \
+     "
+     # Add network-legacy for SP2
+   ```
+
+10. Apply any site-specific customizations and modifications to the Ansible configuration for the UAN nodes and commit the changes.
 
     The default Ansible play to configure UAN nodes is `site.yml` in the base of the `uan-config-management` repository. The roles that are executed in this play allow for custom configuration as required for the system.
 
@@ -128,7 +145,7 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
      create mode 100644 group_vars/Application_UAN/vars.yml
     ```
 
-10. Push the changes to the repository using the proper credentials, including the password obtained previously.
+11. Push the changes to the repository using the proper credentials, including the password obtained previously.
 
     ```bash
     ncn-m001# git push --set-upstream origin integration


### PR DESCRIPTION
Recreating [PR](https://github.com/Cray-HPE/uan-product-stream/pull/43) for correct branch

## Summary and Scope

Changed the text and command in one step and inserted another step for a WAR.

docs-only change made necessary by SKERN-6718. This PR is for UAN 2.4


## Issues and Related PRs

 [CASMUSER-3059](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3059)
[SKERN-6718](https://jira-pro.its.hpecorp.net:8443/browse/SKERN-6718)


## Testing

Local docs builds made on WSL2/Ubuntu and formatting verified on the test ITG docs portal.


## Risks and Mitigations
 
No known risks.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [*] License file intact
- [*] Target branch correct
- [ ] CHANGELOG.md updated
- [*] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

