### PR TITLE
Add a container to the vault exec command

### DIFF
--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -53,7 +53,7 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
     The vault login command will request a token. That token value is the output of the previous step. The vault `read secret/uan` command verifies that the hash was stored correctly. This password hash will be written to the UAN for the `root` user by CFS.
 
     ```bash
-    ncn-m001# kubectl exec -it -n vault cray-vault-0 -- sh
+    ncn-m001# kubectl exec -it -n vault cray-vault-0 -c vault -- sh
     export VAULT_ADDR=http://cray-vault:8200
     vault login
     vault write secret/uan root_password='HASH'


### PR DESCRIPTION
## Summary and Scope

The exec command now requires a container be specified.

## Issues and Related PRs

* Resolves [CASMUSER-3072](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3072)

## Testing

`surtur`

### Test description:

New command works w/o chatter from k8s

## Risks and Mitigations
 none

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

