### PR TITLE
updated date and release version in ditamaps

### DIFF
--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.0"></data>
+		<data name="edition" value="UAN Software Release 2.5.4"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.0"></data>
+			<data name="edition" value="UAN Software Release 2.5.4"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrades.md" format="markdown"/>


### PR DESCRIPTION
## Summary and Scope

Just updated the month and UAN version number in the ditamap for each UAN guide. This change only affects the metadata that appears on the landing page of the guides on HPESC so that it'll be correct for the next HPE Cray EX software release.

## Issues and Related PRs

* Resolves [CASMUSER-3081](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3081)

## Testing

Tested by producing HTML5 bundles locally in Ubuntu & WSL2 and uploading both guides to HPESC and inspecting the landing pages.

## Risks and Mitigations

The only risk is that the next HPE Cray EX software release won't use UAN 2.5.4 and I'll have to do this again.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

