### PR TITLE
UAN 2.5.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.5] - 2022-10-05
+- Disable cray-ifconf
+- Fix edge case in uan_interfaces
+
 ## [2.5.4] - 2022-09-07
 - Update UAN with the latest COS CFS changes
 - Use a new cf-gitea-import

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.4"></data>
+		<data name="edition" value="UAN Software Release 2.5.5"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.4"></data>
+			<data name="edition" value="UAN Software Release 2.5.5"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrades.md" format="markdown"/>

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.1
-UAN_CONFIG_VERSION=1.9.4
+UAN_CONFIG_VERSION=1.9.7
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

## [2.5.5] - 2022-10-05
- Disable cray-ifconf
- Fix edge case in uan_interfaces

## Issues and Related PRs

* Resolves CASMUSER-3101 CASMUSER-3102

## Testing

`tyr` CAN
`surtur` CHN
`shandy` empty "child" cabinent

## Risks and Mitigations

Disabling `cray-ifconf` reverts UAN to the previous working `uan_interface` role.
CASMUSER-3101 covers an SLS json structure edge case


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

