### PR TITLE
Correct the regex used for salt

### DIFF
--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -39,7 +39,7 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 2. **Optional** Generate the password hash for the `root` user. Replace PASSWORD with the `root` password you wish to use.  If an upgrade or image rebuild is being performed, the root password may have already been added to vault.
 
     ```bash
-    ncn-m001# openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) PASSWORD
+    ncn-m001# openssl passwd -6 -salt $(< /dev/urandom tr -dc ./A-Za-z0-9 | head -c4) PASSWORD
     ```
 
 3. **Optional** Obtain the HashiCorp Vault `root` token.


### PR DESCRIPTION
## Summary and Scope

This PR resolves CASMUSER-3112 correcting an issue where the regex used for salt was allowing illegal characters, namely "_".  This is documentation only change to the command line used for generating the password hash used for UANs.

## Issues and Related PRs

* Resolves [CASMUSER-3112](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3112)

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

