### PR TITLE
UAN 2.5.6

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.6] - 2022-10-14
+- Fix issue configuring CHN on computes nodes after COS 2.4.79 enabled cray-ifconf
+
 ## [2.5.5] - 2022-10-05
 - Disable cray-ifconf
 - Fix edge case in uan_interfaces

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.5"></data>
+		<data name="edition" value="UAN Software Release 2.5.6"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.5"></data>
+			<data name="edition" value="UAN Software Release 2.5.6"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrade_UAN_Software_Product.md" format="markdown"/>

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.1
-UAN_CONFIG_VERSION=1.9.7
+UAN_CONFIG_VERSION=1.9.8
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

[2.5.6] - 2022-10-14
- Fix issue configuring CHN on computes nodes after COS 2.4.79 enabled cray-ifconf

## Issues and Related PRs

* Resolves [CASMUSER-3111](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3111)

## Testing

  * `surtur`
  
### Test description:

Verified the UAN and computes could complete CHN configuration

## Risks and Mitigations

This was done with hand patched UANs and Computes, but we verified`systemctl restart wicked` would not
cause the node to hang and `cray-ifconf` had run before wicked.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

