### PR TITLE
CASMUSER_3122: Add docs-product-manifest.yaml for unified docs support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add support for unified docs project - docs-product-manifest.yaml
 
 ## [2.5.6] - 2022-10-14
 - Fix issue configuring CHN on computes nodes after COS 2.4.79 enabled cray-ifconf

--- a/docs/portal/developer-portal/docs-product-manifest.yaml
+++ b/docs/portal/developer-portal/docs-product-manifest.yaml
@@ -1,0 +1,7 @@
+name: uan
+version: 2.6.0
+docs_product_manifest_version: ^0.1.0 # Keep this field like this until further notice
+ 
+csm-based-install-docs: uan_install_guide.md
+ 
+csm-based-upgrade-docs: uan_install_guide.md


### PR DESCRIPTION
## Summary and Scope

Add a docs-product-manifest.yaml in compliance with the new unified documentation project.

## Issues and Related PRs

* Resolves [CASMUSER-3122](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3122)
* Merge with PR for CASMUSER-3121

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [X] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

