### PR TITLE
UAN 2.6.0-alpha.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Restructure UAN CFS and remove COS CFS roles
+- Update Application image to 0.2.1
+- Enable install.sh to work on GCP vshastav2
 - Add support for unified docs project - docs-product-manifest.yaml
 - Update documentation for new COS CFS layers
 

--- a/docs/portal/developer-portal/docs-product-manifest.yaml
+++ b/docs/portal/developer-portal/docs-product-manifest.yaml
@@ -1,5 +1,5 @@
 name: @name@
-version: @product_version*
+version: @product_version@
 docs_product_manifest_version: @doc_product_manifest_version@ # Keep this field like this until further notice
  
 csm-based-install-docs: uan_install_guide.md

--- a/docs/portal/developer-portal/docs-product-manifest.yaml
+++ b/docs/portal/developer-portal/docs-product-manifest.yaml
@@ -1,6 +1,6 @@
-name: uan
-version: 2.6.0
-docs_product_manifest_version: ^0.1.0 # Keep this field like this until further notice
+name: @name@
+version: @product_version*
+docs_product_manifest_version: @doc_product_manifest_version@ # Keep this field like this until further notice
  
 csm-based-install-docs: uan_install_guide.md
  

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -183,7 +183,7 @@ configurations:
     playbook: cos-application.yml
     product:
       name: cos
-      version: 2.4
+      version: 2.5
   - name: csm-packages-integration
     playbook: csm_packages.yml
     product:
@@ -198,11 +198,11 @@ configurations:
   
   ... add configuration layers for other products here, if desired ...
 
-  - name: cos-application-last-integration
-    playbook: cos-application-after.yml
+  - name: uan-rebuild-initrd
+    playbook: rebuild-initrd.yml
     product:
-      name: cos
-      version: 2.4
+      name: uan
+      version: 2.6.0
       branch: integration
 ```
 

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.6"></data>
+		<data name="edition" value="UAN Software Release @product_version@"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.6"></data>
+			<data name="edition" value="UAN Software Release @product_version@"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrade_UAN_Software_Product.md" format="markdown"/>

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -50,4 +50,7 @@ When an upgrade is being performed, please review the notable changes for **all*
 
 ## UAN 2.6.0
 
-* UAN CFS configurations now require a CSM and two COS layers.
+* UAN CFS configurations now require a CSM and two COS layers. Roles that were duplicated from COS CFS in the UAN CFS repo have been removed.
+  * Values for COS CFS roles that were previously set in the UAN CFS group_vars directory should now be set in COS CFS group_vars
+* UAN CFS has been restructured to work for COS and Standard SLES images
+* uan_packages variables are now vars/uan_packages.yml and vars/uan_repos.yml and have been renamed. Admins will need to migrate to the new settings.

--- a/init-ims-image.sh
+++ b/init-ims-image.sh
@@ -33,13 +33,13 @@ BUCKET=boot-images
 function check_auth() {
 
   # Check if a Cray CLI configuration exists...
-  if cray uas mgr-info list 2>&1 | egrep --silent "Error: No configuration exists"; then
+  if cray ims images list 2>&1 | egrep --silent "Error: No configuration exists"; then
     echo "cray command not initialized. Initialize with 'cray init' and try again"
     exit 1
   fi
 
   # Check if Cray CLI has a valid authentication token...
-  if cray uas mgr-info list 2>&1 | egrep --silent "Token not valid for UAS|401|403"; then
+  if cray ims images list 2>&1 | egrep --silent "401|403"; then
     echo "cray command not authorized. Authorize with 'cray auth login' and try again"
     exit 1
   fi

--- a/install.sh
+++ b/install.sh
@@ -95,9 +95,9 @@ fi
 loftsman ship --charts-path "${ROOTDIR}/helm" --manifest-path "${ROOTDIR}/build/manifests/uan.yaml"
 
 ARTIFACT_PATH=${ROOTDIR}/images/application
-KERNEL=${ARTIFACT_PATH}/$UAN_KERNEL_VERSION.kernel
-INITRD=${ARTIFACT_PATH}/initrd.img.xz
-ROOTFS=${ARTIFACT_PATH}/application.squashfs
+KERNEL=${ARTIFACT_PATH}/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION.kernel
+INITRD=${ARTIFACT_PATH}/initrd.img-$UAN_IMAGE_VERSION.xz
+ROOTFS=${ARTIFACT_PATH}/application-$UAN_IMAGE_VERSION.squashfs
 
 # Check for the existence of the SLES image to be installed
 IMAGE_ID=$(list_ims_images | jq --arg UAN_IMAGE_NAME "$UAN_IMAGE_NAME" -r 'sort_by(.created) | .[] | select(.name == $UAN_IMAGE_NAME ) | .id' | head -1)

--- a/release.sh
+++ b/release.sh
@@ -55,7 +55,7 @@ function copy_docs {
     DATE="`date`"
     rsync -aq "${ROOTDIR}/docs/" "${BUILDDIR}/docs/"
     # Set any dynamic variables in the UAN docs
-    for docfile in `find "${BUILDDIR}/docs/" -name "*.md" -type f`;
+    for docfile in `find "${BUILDDIR}/docs/" -name "*.md" -o -name "*.ditamap" -type f`;
     do
         sed -i.bak -e "s/@product_version@/${VERSION}/g" "$docfile"
         sed -i.bak -e "s/@date@/${DATE}/g" "$docfile"

--- a/release.sh
+++ b/release.sh
@@ -55,9 +55,11 @@ function copy_docs {
     DATE="`date`"
     rsync -aq "${ROOTDIR}/docs/" "${BUILDDIR}/docs/"
     # Set any dynamic variables in the UAN docs
-    for docfile in `find "${BUILDDIR}/docs/" -name "*.md" -o -name "*.ditamap" -type f`;
+    for docfile in `find "${BUILDDIR}/docs/" -name "*.md" -o -name "*.ditamap" -o -name "*.yaml" -type f`;
     do
         sed -i.bak -e "s/@product_version@/${VERSION}/g" "$docfile"
+        sed -i.bak -e "s/@name@/${NAME}/g" "$docfile"
+        sed -i.bak -e "s/@doc_product_manifest_version@/${DOC_PRODUCT_MANIFEST_VERSION}/g" "$docfile"
         sed -i.bak -e "s/@date@/${DATE}/g" "$docfile"
     done
     for bakfile in `find "${BUILDDIR}/docs/" -name "*.bak" -type f`;

--- a/vars.sh
+++ b/vars.sh
@@ -42,6 +42,9 @@ UAN_KERNEL_VERSION=5.3.18-150300.59.87-default
 UAN_IMAGE_NAME=cray-application-sles15sp3.x86_64-$UAN_IMAGE_VERSION
 UAN_IMAGE_URL=https://artifactory.algol60.net/artifactory/user-uan-images/$UAN_IMAGE_RELEASE/application
 
+# Versions for doc product manifest
+DOC_PRODUCT_MANIFEST_VERSION="^0.1.0" # Keep this field like this until further notice
+
 APPLICATION_ASSETS=(
     $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/application-$UAN_IMAGE_VERSION.squashfs
     $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION.kernel

--- a/vars.sh
+++ b/vars.sh
@@ -32,20 +32,20 @@ MINOR=`./vendor/semver get minor ${VERSION}`
 PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
-PRODUCT_CATALOG_UPDATE_VERSION=1.3.1
-UAN_CONFIG_VERSION=1.9.8
+PRODUCT_CATALOG_UPDATE_VERSION=1.6.0
+UAN_CONFIG_VERSION=1.10.1
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable
-UAN_IMAGE_VERSION=0.1.0
+UAN_IMAGE_VERSION=0.2.1
 UAN_KERNEL_VERSION=5.3.18-150300.59.87-default
 UAN_IMAGE_NAME=cray-application-sles15sp3.x86_64-$UAN_IMAGE_VERSION
 UAN_IMAGE_URL=https://artifactory.algol60.net/artifactory/user-uan-images/$UAN_IMAGE_RELEASE/application
 
 APPLICATION_ASSETS=(
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/application.squashfs
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION.kernel
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/initrd.img.xz
+    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/application-$UAN_IMAGE_VERSION.squashfs
+    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION.kernel
+    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/initrd.img-$UAN_IMAGE_VERSION.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

Roll up the changes since UAN 2.5.6 into UAN 2.6.0-alpha.0
```
- Restructure UAN CFS and remove COS CFS roles
- Update Application image to 0.2.1
- Enable install.sh to work on GCP vshastav2
- Add support for unified docs project - docs-product-manifest.yaml
- Update documentation for new COS CFS layers
```

## Testing

vshasta-v2
tyr

### Test description:

Installed on vshasta-v2
Built COS image on tyr
Built SLE Application on tyr
Inspected for doc changes to ditamap and yaml files

## Risks and Mitigations

Somewhat

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

