### PR TITLE
Revert to an earlier version of cray-product-catalog-update

### DIFF
--- a/vars.sh
+++ b/vars.sh
@@ -32,7 +32,7 @@ MINOR=`./vendor/semver get minor ${VERSION}`
 PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
-PRODUCT_CATALOG_UPDATE_VERSION=1.6.0
+PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
 UAN_CONFIG_VERSION=1.10.1
 
 # Versions for UAN images


### PR DESCRIPTION
Tested on vshasta-v2, the version of cray-product-catalog-update being reverted is hitting [CASMCMS-8002](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8002).