### PR TITLE
Casmuser 3138: Updates for UAN 2.4.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,9 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.4.5] - 2022-12-05
-- Update to pick up newer COS roles for kdump and cray_dvs_install
-
 ## [2.4.4] - 2022-08-25
 - Update uan_interfaces to optimize SLS queries
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.5] - 2022-12-05
+- Update to pick up newer COS roles, kdump and cray_dvs_install
+
 ## [2.4.4] - 2022-08-25
 - Update uan_interfaces to optimize SLS queries
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.5] - 2022-12-05
+- Update to pick up newer COS roles for kdump and cray_dvs_install
+
 ## [2.4.4] - 2022-08-25
 - Update uan_interfaces to optimize SLS queries
 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 1.8.9
+    - 1.8.8
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:
-    - 1.8.8
+    - 1.8.9
 
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.8.8
+    - 1.8.9

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -24,4 +24,4 @@
 https://artifactory.algol60.net/artifactory/uan-helm-charts/:
   charts:
     cray-uan-install:
-    - 1.8.9
+    - 1.8.8

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.8.9
+    version: 1.8.8
     namespace: services
     values:
       cray-import-config:

--- a/manifests/uan.yaml
+++ b/manifests/uan.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   charts:
   - name: cray-uan-install
-    version: 1.8.8
+    version: 1.8.9
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This PR is to build UAN 2.4.5 which picks up newer kdump and cray_dvs_install CFS roles from COS.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMUSER-3138](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3138)

## Testing

### Tested on:

  * `vale`

### Test description:

Verified adding the newer roles fixed the issue with kdump not being installed in the UAN image.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

