### PR TITLE
CASMUSER-3008: Add support for K3s/MetalLB/HAProxy/SSHD (foundation for UAIs on UAN)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for unified docs project - docs-product-manifest.yaml
 - Update documentation for new COS CFS layers
 - Add support for the install and upgrade framework (IUF)
+- Include assets for k3s, haproxy, and metallb
+- Update to support CFS for k3s, haproxy, and metallb
 
 ## [2.5.6] - 2022-10-14
 - Fix issue configuring CHN on computes nodes after COS 2.4.79 enabled cray-ifconf

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -53,7 +53,7 @@ pipeline {
     }
 
     stages {
-        stage {
+        stage("Build") {
             parallel {
                 stage("Release") {
                     steps {
@@ -75,14 +75,14 @@ pipeline {
                     }
                 }
             }
-            stage("Publish") {
-                steps {
-                    withCredentials([
-                            usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                        ]) {
-                        script {
-                            publishUan(isStable: env.IS_STABLE, version: env.RELEASE_VERSION, pattern: "${WORKSPACE}/dist/uan-"+env.RELEASE_VERSION+".tar.gz")
-                        }
+        }
+        stage("Publish") {
+            steps {
+                withCredentials([
+                        usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                    ]) {
+                    script {
+                        publishUan(isStable: env.IS_STABLE, version: env.RELEASE_VERSION, pattern: "${WORKSPACE}/dist/uan-"+env.RELEASE_VERSION+".tar.gz")
                     }
                 }
             }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -53,40 +53,42 @@ pipeline {
     }
 
     stages {
-        parallel {
-            stage("Build release") {
-                steps {
-                      withCredentials([
-                                usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                        ]) {
-                        sh "make generate_release"
+        stage {
+            parallel {
+                stage("Release") {
+                    steps {
+                          withCredentials([
+                                    usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                            ]) {
+                            sh "make generate_release"
+                        }
+                    }
+                }
+
+                stage("Docs") {
+                    steps {
+                          withCredentials([
+                                    usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                            ]) {
+                            sh "make build_docs"
+                        }
                     }
                 }
             }
-
-            stage("Build docs") {
+            stage("Publish") {
                 steps {
-                      withCredentials([
-                                usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                    withCredentials([
+                            usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
                         ]) {
-                        sh "make build_docs"
+                        script {
+                            publishUan(isStable: env.IS_STABLE, version: env.RELEASE_VERSION, pattern: "${WORKSPACE}/dist/uan-"+env.RELEASE_VERSION+".tar.gz")
+                        }
                     }
                 }
             }
         }
     }
 
-    stage("Publish") {
-        steps {
-            withCredentials([
-                    usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                ]) {
-                script {
-                    publishUan(isStable: env.IS_STABLE, version: env.RELEASE_VERSION, pattern: "${WORKSPACE}/dist/uan-"+env.RELEASE_VERSION+".tar.gz")
-                }
-            }
-        }
-    }
 
     post {
         always {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -53,24 +53,36 @@ pipeline {
     }
 
     stages {
-        stage("Build") {
-            steps {
-                  withCredentials([
-                            usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                    ]) {
-                    sh "make"
+        parallel {
+            stage("Build release") {
+                steps {
+                      withCredentials([
+                                usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                        ]) {
+                        sh "make generate_release"
+                    }
+                }
+            }
+
+            stage("Build docs") {
+                steps {
+                      withCredentials([
+                                usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                        ]) {
+                        sh "make build_docs"
+                    }
                 }
             }
         }
+    }
 
-        stage("Publish") {
-            steps {
-                  withCredentials([
-                            usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-                    ]) {
-                    script {
-                        publishUan(isStable: env.IS_STABLE, version: env.RELEASE_VERSION, pattern: "${WORKSPACE}/dist/uan-"+env.RELEASE_VERSION+".tar.gz")
-                    }
+    stage("Publish") {
+        steps {
+            withCredentials([
+                    usernamePassword(credentialsId: 'artifactory-algol60-publish', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
+                ]) {
+                script {
+                    publishUan(isStable: env.IS_STABLE, version: env.RELEASE_VERSION, pattern: "${WORKSPACE}/dist/uan-"+env.RELEASE_VERSION+".tar.gz")
                 }
             }
         }

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-artifactory.algol60.net/uan-docker/stable:
+artifactory.algol60.net/uan-docker/unstable:
   tls-verify: true
   images:
     cray-uan-config:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-artifactory.algol60.net/uan-docker/unstable:
+artifactory.algol60.net/uan-docker/stable:
   tls-verify: true
   images:
     cray-uan-config:

--- a/include/nexus-upload.sh
+++ b/include/nexus-upload.sh
@@ -34,5 +34,4 @@ nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 
 # Upload repository contents
 nexus-upload raw "${ROOTDIR}/rpms/sle-15sp4" "uan-@major@.@minor@.@patch@-sle-15sp4"
-nexus-upload raw "${ROOTDIR}/rpms/sle-15sp3" "uan-@major@.@minor@.@patch@-sle-15sp3"
 nexus-upload raw "${ROOTDIR}/third-party" "uan-@major@.@minor@.@patch@-third-party"

--- a/include/nexus-upload.sh
+++ b/include/nexus-upload.sh
@@ -35,3 +35,4 @@ nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 # Upload repository contents
 nexus-upload raw "${ROOTDIR}/rpms/sle-15sp4" "uan-@major@.@minor@.@patch@-sle-15sp4"
 nexus-upload raw "${ROOTDIR}/rpms/sle-15sp3" "uan-@major@.@minor@.@patch@-sle-15sp3"
+nexus-upload raw "${ROOTDIR}/third-party" "uan-@major@.@minor@.@patch@-third-party"

--- a/manifests/iuf-product-manifest.yaml
+++ b/manifests/iuf-product-manifest.yaml
@@ -54,6 +54,9 @@ content:
   - path: rpms/sle-15sp3
     repository_name: uan-@major@.@minor@.@patch@-sle-15sp3
     repository_type: raw
+  - path: third-party
+    repository_name: uan-@major@.@minor@.@patch@-third-party
+    repository_type: raw
 
   vcs:
     path: ansible

--- a/manifests/iuf-product-manifest.yaml
+++ b/manifests/iuf-product-manifest.yaml
@@ -51,9 +51,6 @@ content:
   - path: rpms/sle-15sp4
     repository_name: uan-@major@.@minor@.@patch@-sle-15sp4
     repository_type: raw
-  - path: rpms/sle-15sp3
-    repository_name: uan-@major@.@minor@.@patch@-sle-15sp3
-    repository_type: raw
   - path: third-party
     repository_name: uan-@major@.@minor@.@patch@-third-party
     repository_type: raw

--- a/nexus-repositories.yaml.tmpl
+++ b/nexus-repositories.yaml.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 ---
 name: @name@-@major@.@minor@.@patch@-sle-15sp4
 format: raw
@@ -16,17 +16,17 @@ group:
   - @name@-@major@.@minor@.@patch@-sle-15sp4
 
 ---
-name: @name@-@major@.@minor@.@patch@-sle-15sp3
+name: @name@-@major@.@minor@.@patch@-third-party
 format: raw
 storage:
   blobStoreName: @name@
 
 ---
-name: @name@-@major@.@minor@-sle-15sp3
+name: @name@-@major@.@minor@-third-party
 format: raw
 storage:
   blobStoreName: @name@
 type: group
 group:
   memberNames:
-  - @name@-@major@.@minor@.@patch@-sle-15sp3
+  - @name@-@major@.@minor@.@patch@-third-party

--- a/release.sh
+++ b/release.sh
@@ -103,7 +103,6 @@ function sync_repo_content {
 
     # sync uan repos from bloblet
     reposync "${BLOBLET_URL}/sle-15sp4" "${BUILDDIR}/rpms/sle-15sp4"
-    reposync "${BLOBLET_URL}/sle-15sp3" "${BUILDDIR}/rpms/sle-15sp3"
 }
 
 function sync_third_party_content {

--- a/release.sh
+++ b/release.sh
@@ -55,7 +55,7 @@ function copy_manifests {
 
     rsync -aq "${ROOTDIR}/helm/" "${BUILDDIR}/helm/"
     # Set any dynamic variables in the UAN manifest
-    sed -i -e "s/@uan_version@/1.11.0-20230119213631+71e9b6d/g" "${BUILDDIR}/helm/index.yaml"
+    sed -i -e "s/@uan_version@/${UAN_CONFIG_VERSION}/g" "${BUILDDIR}/helm/index.yaml"
 }
 
 function copy_tests {

--- a/release.sh
+++ b/release.sh
@@ -55,7 +55,7 @@ function copy_manifests {
 
     rsync -aq "${ROOTDIR}/helm/" "${BUILDDIR}/helm/"
     # Set any dynamic variables in the UAN manifest
-    sed -i -e "s/@uan_version@/${UAN_CONFIG_VERSION}/g" "${BUILDDIR}/helm/index.yaml"
+    sed -i -e "s/@uan_version@/1.11.0-20230119213631+71e9b6d/g" "${BUILDDIR}/helm/index.yaml"
 }
 
 function copy_tests {

--- a/rpm/cray/uan/sle-15sp4/index.yaml
+++ b/rpm/cray/uan/sle-15sp4/index.yaml
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+https://artifactory.algol60.net/artifactory/uan-rpms/hpe/stable/sle-15sp4/:
+  rpms:
+    - cray-uan-boot-parameters-shasta-uan-1.2.0-1.x86_64
+    - cray-uan-diagnostics-1.2.0-1.x86_64
+    - cray-uan-load-drivers-shasta-uan-1.2.0-1.x86_64
+    - cray-uan-goss-0.3.18-1.noarch
+    - cray-uan-systemd-presets-1.2.0-1.noarch

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.11.0-20230119213631_71e9b6d
+UAN_CONFIG_VERSION=1.11.0
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.10.1
+UAN_CONFIG_VERSION=1.11.0-20230119213631_71e9b6d
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable

--- a/vars.sh
+++ b/vars.sh
@@ -42,6 +42,15 @@ UAN_KERNEL_VERSION=5.3.18-150300.59.87-default
 UAN_IMAGE_NAME=cray-application-sles15sp3.x86_64-$UAN_IMAGE_VERSION
 UAN_IMAGE_URL=https://artifactory.algol60.net/artifactory/user-uan-images/$UAN_IMAGE_RELEASE/application
 
+# Dependencies for UAIs on Application nodes
+K3S_VERSION=1.26.0
+METALLB_VERSION=0.13.7
+HAPROXY_VERSION=1.17.3
+K3S_URL=https://github.com/k3s-io/k3s/releases/download/v$K3S_VERSION%2Bk3s1
+K3S_INSTALLER=https://get.k3s.io
+METALLB_URL=https://metallb.github.io/metallb
+HAPROXY_URL=https://haproxytech.github.io/helm-charts
+
 # Versions for doc product manifest
 DOC_PRODUCT_MANIFEST_VERSION="^0.1.0" # Keep this field like this until further notice
 
@@ -49,6 +58,12 @@ APPLICATION_ASSETS=(
     $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/application-$UAN_IMAGE_VERSION.squashfs
     $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION.kernel
     $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/initrd.img-$UAN_IMAGE_VERSION.xz
+)
+
+THIRD_PARTY_ASSETS=(
+    $K3S_URL/k3s
+    $K3S_URL/k3s-airgap-images-amd64.tar
+    $K3S_INSTALLER/k3s-install.sh
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
@@ -418,7 +418,7 @@ function skopeo-sync() {
                 -v "$(realpath "$index"):/index.yaml:ro" \
                 -v "$(realpath "$destdir"):/data" \
                 "$SKOPEO_IMAGE" \
-                sync --retry-times 5 --src yaml --dest dir --scoped /index.yaml /data
+                sync --src-creds "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" --retry-times 5 --src yaml --dest dir --scoped /index.yaml /data
         then
             function_rc=0
             echo "$(date) skopeo-sync: Attempt #${attempt_number} PASSED!"


### PR DESCRIPTION
## Summary and Scope

CASMUSER-3008: Initial support for installing k3s, metallb, haproxy, sshd

Add roles necessary to support UAIs on UAN. This includes:
uan_k3s_stage - Pull k3s assets to the image
uan_k3s_install - Install k3s master on a node
uan_helm - Initialize environment for helm
uan_metallb - Install MetalLB chart
uan_haproxy - Install HAProxy charts
uan_sshd - Install and configure SSHD instances

To use the new roles, a playbook "k3s.yml" has been added. By default, MetalLB will be installed without an IPAddressPool unless configuration action is taken.

Additionally, an example HAProxy configuration is included to show a default SSH load balancer that can be further extended to support UAIs using podman.

Other changes include:
* Support for authenticated endpoints in algol60 domain
* Remove SP3 zypper repo
* Add parallel build stage for docs and release

## Issues and Related PRs

* Resolves [CASMUSER-3008](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3008)

## Testing

  * `surtur` `hermod`
  * Local development environment
  * Virtual Shasta

### Test description:

Ran an image build and node personalization many times to configure a single node k3s UAN
that could log a user into a podman shell:
```
arbus ~/github/uan (k3s) $ ssh x.x.x.x
(alanm@x.x.x.x) Password:
Your password will expire in 276 day(s).
WARN[0000] Path "/etc/SUSEConnect" from "/etc/containers/mounts.conf" doesn't exist, skipping
WARN[0000] Path "/etc/zypp/credentials.d/SCCcredentials" from "/etc/containers/mounts.conf" doesn't exist, skipping
sh-4.4$

alanm@uan01:~> podman ps
CONTAINER ID  IMAGE                        COMMAND     CREATED         STATUS             PORTS       NAMES
0deb7cde4c1c  registry.local/cray/uai:1.0              44 seconds ago  Up 44 seconds ago              xenodochial_chebyshev
alanm@uan01:~>
```

## Risks and Mitigations

This feature is considered a Technical Preview, so the configs are likely to need changes or be expanded on.
As the playbook is not run by default, the risk to impacting nominal UAN installations is zero

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

