### PR TITLE
Casmuser 3159: Change install.sh to use registry.local for installation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.8] - 2023-01-14
+- Fix issue with air-gapped installs
+
 ## [2.5.7] - 2022-11-17
 - Fix issue with kdump role position in site.yml
 

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.7"></data>
+		<data name="edition" value="UAN Software Release 2.5.8"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.7"></data>
+			<data name="edition" value="UAN Software Release 2.5.8"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrade_UAN_Software_Product.md" format="markdown"/>

--- a/install.sh
+++ b/install.sh
@@ -112,4 +112,4 @@ podman run --rm --name uan-$UAN_PRODUCT_VERSION-image-catalog-update \
     -e KUBECONFIG=/.kube/admin.conf \
     -v /etc/kubernetes:/.kube:ro \
     -v ${PWD}:/results:ro \
-    artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$PRODUCT_CATALOG_UPDATE_VERSION
+    registry.local/artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$PRODUCT_CATALOG_UPDATE_VERSION

--- a/release.sh
+++ b/release.sh
@@ -89,9 +89,20 @@ function sync_repo_content {
     # sync container images
     skopeo-sync "${BUILDDIR}/docker/index.yaml" "${BUILDDIR}/docker"
 
+    if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
+        REPOCREDSPATH="/tmp/"
+        REPOCREDSFILENAME="repo_creds.json"
+        jq --null-input   --arg url "https://artifactory.algol60.net/artifactory/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSPATH$REPOCREDSFILENAME
+        REPO_CREDS_DOCKER_OPTIONS="--mount type=bind,source=${REPOCREDSPATH},destination=/repo_creds_data"
+        REPO_CREDS_RPMSYNC_OPTIONS="-c /repo_creds_data/${REPOCREDSFILENAME}"
+        trap "rm -f '${REPOCREDSPATH}${REPOCREDSFILENAME}'" EXIT
+    fi
+
     # sync uan repos from bloblet
-    reposync "${BLOBLET_URL}/sle-15sp4" "${BUILDDIR}/rpms/sle-15sp4"
-    reposync "${BLOBLET_URL}/sle-15sp3" "${BUILDDIR}/rpms/sle-15sp3"
+    rpm-sync "${ROOTDIR}/rpm/cray/uan/sle-15sp4/index.yaml" "${BUILDDIR}/rpms/sle-15sp4"
+    createrepo "${BUILDDIR}/rpms/sle-15sp4"
+    rpm-sync "${ROOTDIR}/rpm/cray/uan/sle-15sp3/index.yaml" "${BUILDDIR}/rpms/sle-15sp3"
+    createrepo "${BUILDDIR}/rpms/sle-15sp3"
 }
 
 function sync_install_content {
@@ -149,7 +160,7 @@ PYTHONPATH=""
 source "${ROOTDIR}/vars.sh"
 source "${ROOTDIR}/assets.sh"
 source "${VENDOR}/lib/release.sh"
-requires rsync tar generate-nexus-config helm-sync skopeo-sync reposync vendor-install-deps sed realpath
+requires rsync tar generate-nexus-config helm-sync skopeo-sync rpm-sync vendor-install-deps sed realpath
 BUILDDIR="$(realpath -m "$ROOTDIR/dist/${NAME}-${VERSION}")"
 
 # initialize build directory

--- a/rpm/cray/uan/sle-15sp3/index.yaml
+++ b/rpm/cray/uan/sle-15sp3/index.yaml
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+https://artifactory.algol60.net/artifactory/uan-rpms/hpe/stable/sle-15sp3/:
+  rpms:
+    - cray-uan-boot-parameters-shasta-uan-1.2.0-1.x86_64
+    - cray-uan-diagnostics-1.2.0-1.x86_64
+    - cray-uan-load-drivers-shasta-uan-1.2.0-1.x86_64
+    - cray-uan-goss-0.3.18-1.noarch
+    - cray-uan-systemd-presets-1.2.0-1.noarch

--- a/rpm/cray/uan/sle-15sp4/index.yaml
+++ b/rpm/cray/uan/sle-15sp4/index.yaml
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+https://artifactory.algol60.net/artifactory/uan-rpms/hpe/stable/sle-15sp4/:
+  rpms:
+    - cray-uan-boot-parameters-shasta-uan-1.2.0-1.x86_64
+    - cray-uan-diagnostics-1.2.0-1.x86_64
+    - cray-uan-load-drivers-shasta-uan-1.2.0-1.x86_64
+    - cray-uan-goss-0.3.18-1.noarch
+    - cray-uan-systemd-presets-1.2.0-1.noarch

--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
@@ -357,7 +357,7 @@ function skopeo-sync() {
                 -v "$(realpath "$index"):/index.yaml:ro" \
                 -v "$(realpath "$destdir"):/data" \
                 "$SKOPEO_IMAGE" \
-                sync --retry-times 5 --src yaml --dest dir --scoped /index.yaml /data
+                sync --src-creds "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" --retry-times 5 --src yaml --dest dir --scoped /index.yaml /data
         then
             function_rc=0
             echo "$(date) skopeo-sync: Attempt #${attempt_number} PASSED!"


### PR DESCRIPTION
## Summary and Scope

This PR changes the UAN install.sh to use registry.local instead of reaching out to artifactory.algol60.net for the installation process.  It also adds support for building the UAN product with a locked down artifactory.algol60.net.

## Issues and Related PRs

* Resolves [CASMUSER-3159](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3159)[CASMUSER-3159](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3159)

## Testing

### Tested on:

  * `surtur`

### Test description:

Tested on surtur.  Image config failed, likely due to the age of the surtur environment.  Testing of access to the new rpm repo was performed by Alan.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

