### PR TITLE
Resolve CVEs in cray-uan-config for UAN 2.6.x

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for the install and upgrade framework (IUF)
 - Include assets for k3s, haproxy, and metallb
 - Update to support CFS for k3s, haproxy, and metallb
+- Update cf-gitea-import to 1.9.1 for CVE resolution in cray-uan-config
 
 ## [2.5.6] - 2022-10-14
 - Fix issue configuring CHN on computes nodes after COS 2.4.79 enabled cray-ifconf

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.11.1
+UAN_CONFIG_VERSION=1.12.0
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.12.0
+UAN_CONFIG_VERSION=1.12.1
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

This PR fixes the CVEs in cray-uan-config by updating to the latest cf-gitea-import:1.9.1 container as a base.
This PR only fixes the CVEs in cray-uan-config for UAN 2.6.x.

## Issues and Related PRs

* Resolves [CASMUSER-3146](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3146)

## Testing

Built cray-uan-config and scanned with snyk.
