### PR TITLE
Version bump for KUBECONFIG fix

### DIFF
--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.12.1
+UAN_CONFIG_VERSION=1.12.2
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

During testing on lemondrop it was discovered that KUBECONFIG should be set at the top level of a playbook so it is accessible to all roles in the playbook. Previous testing had KUBECONFIG set in the environment already, so it obscured a problem where helm commands would fail to deploy haproxy.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and Kother pull requests. Be sure to list dependencies._

* Resolves [CASMUSER-3177](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3177)

## Testing

`lemondrop`

### Test description:

Tested that new CFS worked correctly and haproxy was installed.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

