### PR TITLE
Update UAN 2.5 to use UAN 1.9.10 artifacts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Update cf-gitea-import to 1.9.1
 
 ## [2.5.8] - 2023-01-14
 - Fix issue with air-gapped installs

--- a/release.sh
+++ b/release.sh
@@ -150,6 +150,11 @@ function sync_image_content {
     popd
 }
 
+if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
+    export REPOCREDSVARNAME="REPOCREDSVAR"
+    export REPOCREDSVAR=$(jq --null-input --arg url "https://artifactory.algol60.net/artifactory/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}')
+fi
+
 # Definitions and sourced variables
 ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
 VENDOR="${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/"

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.1
-UAN_CONFIG_VERSION=1.9.9
+UAN_CONFIG_VERSION=1.9.10
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable

--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 
-: "${PACKAGING_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.3}"
+: "${PACKAGING_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.4}"
 : "${RPM_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/rpm-tools:1.0.0}"
 : "${SKOPEO_IMAGE:=arti.hpc.amslabs.hpecorp.net/quay-remote/skopeo/stable:v1.4.1}"
-: "${CRAY_NEXUS_SETUP_IMAGE:=artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1}"
+: "${CRAY_NEXUS_SETUP_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cray-nexus-setup:0.7.1}"
 : "${ARTIFACTORY_HELPER_IMAGE:=arti.hpc.amslabs.hpecorp.net/dst-docker-master-local/arti-helper:latest}"
-: "${CFS_CONFIG_UTIL_IMAGE:=artifactory.algol60.net/csm-docker/stable/cfs-config-util:3.1.0}"
+: "${CFS_CONFIG_UTIL_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:3.3.1}"
+: "${LIST_IMAGES_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/list-images:1.0.0}"
+: "${SNYK_SCAN_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/snyk-scan:1.1.0}"
+: "${SNYK_AGGREGATE_RESULTS_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/snyk-aggregate-results:1.0.1}"
+: "${SNYK_TO_HTML_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/snyk-to-html:1.0.0}"
+: "${CRAY_NLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cray-nls:0.9.8}"
+
 
 # Prefer to use docker, but for environments with podman
 if [[ "${USE_PODMAN_NOT_DOCKER:-"no"}" == "yes" ]]; then
@@ -89,12 +95,20 @@ function helm-sync() {
 
     [[ -d "$destdir" ]] || mkdir -p "$destdir"
 
-    docker run --rm -u "$(id -u):$(id -g)" ${podman_run_flags[@]} \
+    #pass the repo credentials environment variables to the container that runs helm-sync
+    REPO_CREDS_DOCKER_OPTIONS=""
+    REPO_CREDS_HELMSYNC_OPTIONS=""
+    if [ ! -z "$REPOCREDSVARNAME" ]; then
+        REPO_CREDS_DOCKER_OPTIONS="-e ${REPOCREDSVARNAME}"
+        REPO_CREDS_HELMSYNC_OPTIONS="-c ${REPOCREDSVARNAME}"
+    fi
+    
+    docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -u "$(id -u):$(id -g)" ${podman_run_flags[@]} \
         ${DOCKER_NETWORK:+"--network=${DOCKER_NETWORK}"} \
         -v "$(realpath "$index"):/index.yaml:ro" \
         -v "$(realpath "$destdir"):/data" \
         "$PACKAGING_TOOLS_IMAGE" \
-        helm-sync -n "${HELM_SYNC_NUM_CONCURRENT_DOWNLOADS:-1}" /index.yaml /data
+        helm-sync ${REPO_CREDS_HELMSYNC_OPTIONS} -n "${HELM_SYNC_NUM_CONCURRENT_DOWNLOADS:-1}" /index.yaml /data
 }
 
 # usage: rpm-sync-latest DIRECTORY ARTIFACTORY_RPM_URL
@@ -116,7 +130,7 @@ function rpm-sync-latest() {
             -v "$(realpath "$destdir"):/artifactory/downloads" \
             "$ARTIFACTORY_HELPER_IMAGE" \
             latest-rpms -r "${artifactory_rpm_release_url}" \
-            -d "/artifactory/downloads/${RELEASE_NAME}" \
+            -d "/artifactory/downloads" \
             -u "${HPE_ARTIFACTORY_USR}" \
             -p "${HPE_ARTIFACTORY_PSW}"
 }
@@ -136,14 +150,12 @@ function rpm-sync() {
 
     [[ -d "$destdir" ]] || mkdir -p "$destdir"
 
-    #pass the repo credentials environment variables to the container that runs rpm-index
-    REPO_FILENAME=${REPOCREDSFILENAME:-}
-    REPO_FILENAME_PATH=${REPOCREDSPATH:-}
+   #pass the repo credentials environment variables to the container that runs rpm-sync
     REPO_CREDS_DOCKER_OPTIONS=""
     REPO_CREDS_RPMSYNC_OPTIONS=""
-    if [ ! -z "$REPO_FILENAME" ] && [ ! -z "$REPO_FILENAME_PATH" ]; then
-        REPO_CREDS_DOCKER_OPTIONS="--mount type=bind,source=${REPO_FILENAME_PATH},destination=/repo_creds_data"
-        REPO_CREDS_RPMSYNC_OPTIONS="-c /repo_creds_data/${REPO_FILENAME}"
+    if [ ! -z "$REPOCREDSVARNAME" ]; then
+        REPO_CREDS_DOCKER_OPTIONS="-e ${REPOCREDSVARNAME}"
+        REPO_CREDS_RPMSYNC_OPTIONS="-c ${REPOCREDSVARNAME}"
     fi
 
     docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -u "$(id -u):$(id -g)" ${podman_run_flags[@]} \
@@ -153,6 +165,61 @@ function rpm-sync() {
         "$PACKAGING_TOOLS_IMAGE" \
         rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -n "${RPM_SYNC_NUM_CONCURRENT_DOWNLOADS:-1}" ${FAIL_ON_SIG_ERROR} -v -d /data /index.yaml
 }
+
+# usage: extract-from-container SOURCE DESTINATION KEY
+#
+# Extracts files or directories with names matching the regular expression KEY from the directory-formatted
+# Docker image SOURCE to the directory DESTINATION.
+#
+# input:
+#     SOURCE      -- Directory where the Docker image layers reside
+#     DESTINATION -- Directory where the extracted content should be placed; will be created if it does not exist
+#     KEY         -- Key to match against; Key can be a file or a directory; Either the file or entire directory
+#                    is copied to the destination directory; The key can use the wildcards used in regular expressions for grep.
+# Exit codes:
+#     0 - item found and extracted
+#     1 - item not found or extraction failed
+#
+
+function extract-from-container () {
+    set +e
+    trap - ERR
+    local SRC_DIR=$1
+    local DEST_DIR=$2
+    local KEY=$3
+
+    if [ "$#" -ne 3 ]; then
+        echo "Expected parameters: <Source Directory> <Destination Directory> <Key>";
+        echo "Received $# parameters: $*"
+        exit 1;
+    fi
+
+    if [ ! -d "${SRC_DIR}" ]; then
+        echo "ERROR -- Source directory: ${SRC_DIR} is not a directory."
+        exit 1;
+    fi
+
+    [[ -d "${DEST_DIR}" ]] || mkdir -p "${DEST_DIR}"
+
+    layers="$(find "${SRC_DIR}" -type f | grep -Ev 'manifest|version')"
+    for i in $layers; do
+        file_matches=$(tar --force-local -tf "${i}" 2> /dev/null | grep -o "${KEY}" | sort -u)
+        if [[ -n "$file_matches" ]]; then
+            local cmd="tar --force-local -xf ${i} -C${DEST_DIR} ${file_matches//$'\n'/ }"
+            echo "$cmd"
+            $cmd
+            echo ""
+            # If key found a directory, move the contents out of the directory.
+            name=$(basename "${file_matches}")
+            if [[ -d "${DEST_DIR}"/"${name}" ]]; then
+                shopt -s dotglob
+                cp -a "${DEST_DIR}"/"${name}"/* "${DEST_DIR}"
+                rm -rf "${DEST_DIR:?}"/"${name}"
+            fi
+        fi
+    done
+}
+
 
 # There are some debug statements included in the following Python script and in
 # the skopeo-sync function. These can be removed later, but until we have more
@@ -351,13 +418,17 @@ function skopeo-sync() {
     while [ true ]; do
         echo "$(date) skopeo-sync: Beginning attempt #${attempt_number}"
         attempt_start_seconds=${SECONDS}
+        skopeo_args=("--retry-times" "5" "--src" "yaml" "--dest" "dir" "--scoped")
+        if [ -n "$ARTIFACTORY_USER" ] && [ -n "$ARTIFACTORY_TOKEN" ]; then
+            skopeo_args+=("--src-creds" "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}")
+        fi
 
         if docker run --rm -u "$(id -u):$(id -g)" ${podman_run_flags[@]} \
                 ${DOCKER_NETWORK:+"--network=${DOCKER_NETWORK}"} \
                 -v "$(realpath "$index"):/index.yaml:ro" \
                 -v "$(realpath "$destdir"):/data" \
                 "$SKOPEO_IMAGE" \
-                sync --src-creds "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" --retry-times 5 --src yaml --dest dir --scoped /index.yaml /data
+                sync "${skopeo_args[@]}" "/index.yaml" "/data"
         then
             function_rc=0
             echo "$(date) skopeo-sync: Attempt #${attempt_number} PASSED!"
@@ -520,7 +591,7 @@ function vendor-install-deps() {
             ${DOCKER_NETWORK:+"--network=${DOCKER_NETWORK}"} \
             -v "$(realpath "$destdir"):/data" \
             "$SKOPEO_IMAGE" \
-            copy "docker://${CRAY_NEXUS_SETUP_IMAGE}" "docker-archive:/data/cray-nexus-setup.tar:cray-nexus-setup:${release}" || return
+            copy "docker://${CRAY_NEXUS_SETUP_IMAGE}" "docker-archive:/data/cray-nexus-setup.tar:cray-nexus-setup:${release}"
     fi
 
     if [[ "${include_skopeo:-"yes"}" == "yes" ]]; then
@@ -569,4 +640,107 @@ else
     esac
 fi
 EOF
+}
+
+# usage: list-images INDEX_FILE [INDEX_FILE ... ]
+#
+# Reads one or more index.yaml files specifying container image locations
+# and writes a list to stdout.
+function list-images() {
+    local index_files="$*"
+    local index_file file_path
+    declare -a file_paths
+    declare -a file_mount_options
+    # Get full paths of each file
+    for index_file in $index_files; do
+        file_path="$(realpath "$index_file")"
+        file_paths+=( "$file_path" )
+        file_mount_options+=( "--mount" )
+        file_mount_options+=( "type=bind,src=${file_path},target=${file_path},ro=true" )
+    done
+
+    docker run --user "$(id -u):$(id -g)" --rm "${file_mount_options[@]}" \
+         $LIST_IMAGES_IMAGE "${file_paths[@]}"
+}
+
+# usage: snyk-scan IMAGE [WORKDIR]
+#
+# Scans a container image with Snyk. This will output results
+# into the current working directory.
+function snyk-scan() {
+    local image="$1"
+    local image_basename
+    image_basename="$(basename "$image")"
+    snyk_environment_arguments=("--env" "SNYK_TOKEN=${SNYK_TOKEN}")
+    if [ -n "$ARTIFACTORY_USER" ] && [ -n "$ARTIFACTORY_TOKEN" ]; then
+        snyk_environment_arguments+=("--env" "SNYK_REGISTRY_USERNAME=${ARTIFACTORY_USER}"
+                                     "--env" "SNYK_REGISTRY_PASSWORD=${ARTIFACTORY_TOKEN}")
+    fi
+
+    docker run --user "$(id -u):$(id -g)" --rm "${snyk_environment_arguments[@]}" \
+        --mount "type=bind,src=${PWD},target=/workdir" \
+        "$SNYK_SCAN_IMAGE" "/workdir" "$image" "$image_basename"
+}
+
+# usage: snyk-aggregate-results [--helm-chart-map MAP.csv] SNYK_RESULTS_FILE [SNYK_RESULTS_FILE ...]
+#
+# Aggregates results from one or more `snyk.json` files (the results from snyk-scan)
+# and creates an Excel spreadsheet from them. The spreadsheet is saved to the current
+# working directory. Optionally, pass in a CSV file containing a mapping of containers
+# to helm charts.
+function snyk-aggregate-results() {
+    local args="$*"
+    local container_args file_mount_options arg
+    declare -a container_args
+    declare -a file_mount_options
+    for arg in ${args}; do
+        # If arg is not an option string, then assume it is a file which needs to be mounted.
+        if [[ "$arg" != --* ]]; then
+          file_path="$(realpath "$arg")"
+          container_args+=( "$file_path" )
+          file_mount_options+=( "--mount" )
+          file_mount_options+=( "type=bind,src=${file_path},target=${file_path},ro=true" )
+        else
+          container_args+=( "$arg" )
+        fi
+    done
+    docker run --user "$(id -u):$(id -g)" --rm "${file_mount_options[@]}" \
+        --mount "type=bind,src=${PWD},target=/workdir" \
+        "$SNYK_AGGREGATE_RESULTS_IMAGE" -o "/workdir/snyk.xlsx" "${container_args[@]}"
+}
+
+# usage: snyk-to-html SNYK_RESULTS_DIR
+#
+# Aggregates results from one or more `snyk.json` files (the results from snyk-scan)
+# and creates HTML reports from them. Unlike snyk-aggregate-results which creates a single
+# spreadsheet from multiple snyk results files, this function creates one HTML report per snyk
+# results file. These files are saved in the same directory as `snyk.json`.
+function snyk-to-html() {
+    snyk_results_files="$*"
+    local results_file results_file_dir results_filename
+    for results_file in ${snyk_results_files}; do
+        results_file_dir="$(dirname "$(realpath "$results_file")")"
+        results_filename="$(basename "$results_file")"
+        docker run --user "$(id -u):$(id -g)" --rm \
+            --mount "type=bind,src=${results_file_dir},target=/workdir" \
+            "$SNYK_TO_HTML_IMAGE" -i "/workdir/${results_filename}" -o "/workdir/snyk.html"
+    done
+}
+
+# usage: iuf-validate IUF_PRODUCT_MANIFEST_FILE
+#
+# Validates the given Installation and Upgrade Framework (IUF) Product Manifest
+# file against the IUF Product Manifest schema. On successful validation, the
+# function returns 0. On a failed validation, the errors are printed to stderr,
+# and the function returns 1.
+function iuf-validate() {
+    local manifest_file="$1"
+    local manifest_basename
+    manifest_basename="$(basename "$manifest_file")"
+
+    docker run --rm -u "$(id -u):$(id -g)" ${podman_run_flags[@]} \
+        ${DOCKER_NETWORK:+"--network=${DOCKER_NETWORK}"} \
+        -v "$(realpath "$manifest_file"):/$manifest_basename" \
+        "$CRAY_NLS_IMAGE" \
+        validate "/$manifest_basename"
 }


### PR DESCRIPTION
## Summary and Scope

This PR updates the UAN 2.5 release to use UAN 1.9.10 artifacts which fix CVEs in the cray-uan-config container.

The vendor/github.hpe.com/hpe/hpc-shastarelm-release was updated to match the commit used in by the main branch in order to support locked down artifactory access.  

## Issues and Related PRs

* Resolves [CASMUSER-3146](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3146)

## Testing

### Test description:

Built the cray-uan-config container and scanned for CVEs.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

