### PR TITLE
casmuser-3181: Add NMN bonding to UAN 2.5.9

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,13 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.9] - 2023-03-16
+- Support bonded NMN
 - Update cf-gitea-import to 1.9.1
-
-## [2.5.9] - 2023-03-16
-- Support bonded NMN
-
-## [2.5.9] - 2023-03-16
-- Support bonded NMN
 
 ## [2.5.8] - 2023-01-14
 - Fix issue with air-gapped installs

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Update cf-gitea-import to 1.9.1
 
+## [2.5.9] - 2023-03-16
+- Support bonded NMN
+
 ## [2.5.8] - 2023-01-14
 - Fix issue with air-gapped installs
 

--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -46,6 +46,15 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     # use the Shasta CAN or CHN network for user access.
     # By default, uan_can_setup is set to 'no'.
     uan_can_setup: yes
+
+    ## uan_can_bond_slaves
+    # This variable only applies when the system default route is CAN
+    # and `uan_nmn_bond` is true.
+    # These are the default CAN bond slaves.  They may need to be
+    # changed based on the actual system hardware configuration.
+    uan_can_bond_slaves:
+      - "ens10f1"
+      - "ens1f1"
     ```
 
     To allow a custom default route when CAN or CHN is selected:
@@ -54,6 +63,23 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     ## uan_customer_default_route
     # Allow a custom default route when CAN or CHN is selected.
     uan_customer_default_route: no
+    ```
+
+   To enable bonded NMN interfaces:
+
+    ```bash
+    ## uan_nmn_bond
+    # Set uan_nmn_bond to 'yes' if the site will
+    # implement a bonded NMN connection.
+    # By default, uan_nmn_bond is set to 'no'.
+    uan_nmn_bond: yes
+
+    ## uan_nmn_bond_slaves
+    # These are the default NMN bond slaves.  They may need to be
+    # changed based on the actual system hardware configuration.
+    uan_nmn_bond_slaves:
+      - "ens10f0"
+      - "ens1f0"
     ```
 
     To define interfaces:

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -164,9 +164,47 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-### `uan_can_setup`
+`uan_nmn_bond`
 
-`uan_can_setup` is a boolean variable controlling the configuration of user
+`uan_nmn_bond` is a boolean variable controlling the configuration of the Node Management Network (NMN).
+When true, the NMN network connection will be configured as a bonded pair of interfaces defined by the members of the
+`uan_nmn_bond_slaves` variable. The bonded NMN interface is named `nmnb0`. When false, the NMN network connection
+will be configured as a single interface named `nmn0`.
+
+The default value of `uan_nmn_bond` is `no`.
+
+```yaml
+uan_nmn_bond: no
+```
+
+`uan_nmn_bond_slaves`
+
+`uan_nmn_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_nmn_bond` is true.
+
+The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f0`
+which is the first port of the NIC in slot 10.  
+
+**NOTE:** `ens10f0` is typically the first port of the OCP 25Gb card that
+the node PXE boots.
+
+**IMPORTANT!** The first interface in the list must be the `nmn0` interface which is configured during the
+initial image boot, typically `ens10f0`.  This is required because the MAC address of the `nmn0` interface
+is the MAC associated with the IP address of the UAN.  The bonded `nmnb0` interface and the bond slaves
+will assume this MAC and the IP address of `nmn0` to preserve connectivity.
+
+The second interface is typically the first port of a different 25Gb NIC for resiliency.
+
+The default values of `uan_nmn_bond_slaves` are shown here.  They may need to be changed to match the actual
+node cabling and NIC configuration.
+```yaml
+uan_nmn_bond_slaves:
+  - "ens10f0"
+  - "ens1f0"
+```
+
+`uan_can_setup`
+
+Boolean variable controlling the configuration of user
 access to UAN nodes.  When true, user access is configured over either the
 Customer Access Network (CAN) or Customer High Speed Network (CHN), depending on which is configured on the system.
 
@@ -180,7 +218,26 @@ The default value of `uan_can_setup` is `no`.
 uan_can_setup: no
 ```
 
-### `uan_customer_default_route`
+`uan_can_bond_slaves`
+
+`uan_can_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_can_setup` is true, `uan_nmn_bond` is true, and the Customer Access Network (CAN) is configured on the system.  This variable is ignored if `uan_nmn_bond` is false.
+
+The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f1`
+which is the second port of the NIC in slot 10.  
+
+**NOTE:** `ens10f1` is typically the second port of the OCP 25Gb card and is used as one of the bond
+slaves in the CAN `bond0` interface.
+
+The second interface is typically the second port of a different 25Gb NIC for resiliency.
+
+The default values of `uan_can_bond_slaves` are shown here.  They may need to be changed to match the actual
+node cabling and NIC configuration.
+
+```yaml
+uan_can_bond_slaves:
+  - "ens10f1"
+  - "ens1f1"
+```
 
 `uan_customer_default_route` is a boolean variable that allows the default route
 to be set by the `customer_uan_routes` data when `uan_can_setup` is true.

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.8"></data>
+		<data name="edition" value="UAN Software Release 2.5.9"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.8"></data>
+			<data name="edition" value="UAN Software Release 2.5.9"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrade_UAN_Software_Product.md" format="markdown"/>

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.1
-UAN_CONFIG_VERSION=1.9.10
+UAN_CONFIG_VERSION=1.9.11
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

This PR packages the UAN 1.9.11 uan code which adds NMN bonding to UAN 2.5.8 release.

## Issues and Related PRs

* Resolves [CASMUSER-3181](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3181) for UAN 2.5

## Testing

### Tested on:

  * `surtur`
  * `lemondrop`

### Test description:

Installed on surtur which is configured to have two links for NMN and on lemondrop which has only the one NMN link.
This proved that single legged bonds would still configure.  Also verified that an un-bonded NMN configuration required
no CFS changes from the previous release.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

