### PR TITLE
UAN 2.6.0-alpha.6

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include assets for k3s, haproxy, and metallb
 - Update to support CFS for k3s, haproxy, and metallb
 - Update cf-gitea-import to 1.9.1 for CVE resolution in cray-uan-config
+- NMN Bonding (disabled by default) and CAN interface changes
 
 ## [2.5.6] - 2022-10-14
 - Fix issue configuring CHN on computes nodes after COS 2.4.79 enabled cray-ifconf

--- a/install.sh
+++ b/install.sh
@@ -128,4 +128,4 @@ podman run --rm --name uan-$UAN_PRODUCT_VERSION-image-catalog-update \
     -e KUBECONFIG=/.kube/admin.conf \
     -v /etc/kubernetes:/.kube:ro \
     -v ${PWD}:/results:ro \
-    artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$PRODUCT_CATALOG_UPDATE_VERSION
+    registry.local/artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$PRODUCT_CATALOG_UPDATE_VERSION

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.12.2
+UAN_CONFIG_VERSION=1.12.4
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

* NMN bonding
* Misc K3s fixes

## Testing

Tested image could build, boot, and configure on lemondrop. NMN bonding was left disabled (the default config). 

## Risks and Mitigations

This adds a fair amount of code for nmn bonding, but it is disabled by default. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

