### PR TITLE
CHN update for 2.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.11] - 2023-03-31
+- Update CHN configuration
+
 ## [2.5.10] - 2023-03-21
 - Add preview release of K3s support
 

--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -26,7 +26,7 @@ By default, a direct connection to the site's user network is assumed and the Ad
 
 * When CAN is set as the system default route in SLS and `uan_nmn_bond` is false, the bonded CAN interfaces are determined automatically.  If `uan_nmn_bond` is true, the bonded CAN interfaces must be defined by `uan_can_bond_slaves` \(see [UAN Ansible Roles](UAN_Ansible_Roles.md)\). The default route is set to the bonded CAN interface `can0`.
 
-* When CHN is set as the system default route in SLS, the CHN IP is added to `hsn0` and the default route is set to the CHN.
+* When CHN is set as the system default route in SLS, the CHN IP is added to `hsn0` by default, but can be changed by using setting `uan_chn_device` to the desired interface.  The default route is set to the CHN.
 
 * The Admin may override the CAN/CHN default route by setting `uan_customer_default_route` to true and defining the default route in `customer_uan_routes`.
 
@@ -93,6 +93,14 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     uan_can_bond_slaves:
       - "ens10f1"
       - "ens1f1"
+    ```
+
+    ```bash
+    ## uan_chn_device
+    # This variable allows the admin to select which interface will 
+    # be used for the CHN device.
+    # By default, "hsn0" is used for CHN.
+    uan_chn_device: "hsn0"
     ```
 
     To allow a custom default route when CAN or CHN is selected:

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -166,7 +166,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 `uan_nmn_bond`
 
-`uan_nmn_bond` is a boolean variable controlling the configuration of the Node Management Network (NMN). When true, the NMN network connection will be configured as a bonded pair of interfaces defined by the members of the `uan_nmn_bond_slaves` variable. The bonded NMN interface is named `nmnb0`. When false, the NMN network connection will be configured as a single interface named `nmn0`.
+: `uan_nmn_bond` is a boolean variable controlling the configuration of the Node Management Network (NMN). When true, the NMN network connection will be configured as a bonded pair of interfaces defined by the members of the `uan_nmn_bond_slaves` variable. The bonded NMN interface is named `nmnb0`. When false, the NMN network connection will be configured as a single interface named `nmn0`.
 
 The default value of `uan_nmn_bond` is `no`.
 
@@ -176,7 +176,7 @@ uan_nmn_bond: no
 
 `uan_nmn_bond_slaves`
 
-`uan_nmn_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_nmn_bond` is true.
+: `uan_nmn_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_nmn_bond` is true.
 
 The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f0` which is the first port of the NIC in slot 10.
 
@@ -197,7 +197,7 @@ uan_nmn_bond_slaves:
 
 `uan_can_setup`
 
-`uan_can_setup` is a boolean variable controlling the configuration of user
+: `uan_can_setup` is a boolean variable controlling the configuration of user
 access to UAN nodes.  When true, user access is configured over either the
 Customer Access Network (CAN) or Customer High Speed Network (CHN), depending on which is configured on the system.
 
@@ -213,7 +213,7 @@ uan_can_setup: no
 
 `uan_can_bond_slaves`
 
-`uan_can_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_can_setup` is true, `uan_nmn_bond` is true, and the Customer Access Network (CAN) is configured on the system.  This variable is ignored if `uan_nmn_bond` is false.
+: `uan_can_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_can_setup` is true, `uan_nmn_bond` is true, and the Customer Access Network (CAN) is configured on the system.  This variable is ignored if `uan_nmn_bond` is false.
 
 The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f1` which is the second port of the NIC in slot 10.
 
@@ -229,7 +229,19 @@ uan_can_bond_slaves:
   - "ens1f1"
 ```
 
-`uan_customer_default_route` is a boolean variable that allows the default route
+`uan_chn_device`
+
+: `uan_chn_device` is a variable which can be used to override the default CHN device on the UAN nodes.
+
+The default value of `uan_chn_device` is shown here.
+
+```yaml
+uan_chn_device: "hsn0"
+```
+
+`uan_customer_default_route`
+
+: `uan_customer_default_route` is a boolean variable that allows the default route
 to be set by the `customer_uan_routes` data when `uan_can_setup` is true.
 
 By default, no default route is setup unless `uan_can_setup` is true, which sets the default route to the CAN or CHN.
@@ -251,12 +263,12 @@ This value should not be changed.
 
 `sls_nmn_svcs_name`
 
-: is the Node Management Services Network name used by SLS.
+: `sls_nmn_svcs_name` is the Node Management Services Network name used by SLS.
 This value should not be changed.
 
 `uan_required_dns_options`
 
-`uan_required_dns_options` is a list of DNS options.  By default, `single-request` is set and must not be removed.
+: `uan_required_dns_options` is a list of DNS options.  By default, `single-request` is set and must not be removed.
 
   Example:
 
@@ -267,7 +279,7 @@ This value should not be changed.
 
 `customer_uan_interfaces`
 
-`customer_uan_interfaces` is as list of interface names used for constructing `ifcfg-<customer_uan_interfaces.name>` files. Define ifcfg fields for each interface here. Field names are converted to uppercase in the generated `ifcfg-<name>` file(s).
+: `customer_uan_interfaces` is as list of interface names used for constructing `ifcfg-<customer_uan_interfaces.name>` files. Define ifcfg fields for each interface here. Field names are converted to uppercase in the generated `ifcfg-<name>` file(s).
 
   Interfaces should be defined in order of dependency.
   

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.1
-UAN_CONFIG_VERSION=1.9.12
+UAN_CONFIG_VERSION=1.9.13
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

This PR updates 2.5.11 docs for the updated CHN configuration method.

## Issues and Related PRs

* Resolves [CASMUSER-3184](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3184)
* Resolves [CASMUSER-3185](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3185)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `hela`

### Test description:

Rebooted the UAN on hela after configuring the image to enable cray-ifconf and updating the uan_interfaces role with the new code.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- X ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

