### PR TITLE
Update CHN config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to support CFS for k3s, haproxy, and metallb
 - Update cf-gitea-import to 1.9.1 for CVE resolution in cray-uan-config
 - NMN Bonding (disabled by default) and CAN interface changes
+- Update CHN configuration to support interfaces other than hsn0
 
 ## [2.5.6] - 2022-10-14
 - Fix issue configuring CHN on computes nodes after COS 2.4.79 enabled cray-ifconf

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.12.4
+UAN_CONFIG_VERSION=1.12.5
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

This PR builds the uan-product-stream for the uan 1.12.5 content.  This will be uan-2.6.0-alpha.7.

It includes the CHN configuration update which allows selecting the CHN interface.

## Issues and Related PRs

* Resolves [CASMUSER-3185](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3185)

## Testing

### Tested on:

  * `hela`

### Test description:

Updated the uan_interfaces role and verified the resulting configuration worked as expected.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

