### PR TITLE
CASMTRIAGE-5236: Add missing ansible task to uan_interfaces for CAN

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.12] - 2023-04-19
+- Fix missing backport step in uan_interfaces
+
 ## [2.5.11] - 2023-03-31
 - Update CHN configuration
 

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.11"></data>
+		<data name="edition" value="UAN Software Release 2.5.12"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.11"></data>
+			<data name="edition" value="UAN Software Release 2.5.12"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrade_UAN_Software_Product.md" format="markdown"/>

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.1
-UAN_CONFIG_VERSION=1.9.13
+UAN_CONFIG_VERSION=1.9.14
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope

Remove extraneous filter_plugin from an incorrect path
Add wickedd-nanny restart missing from backport

## Issues and Related PRs

* Resolves [CASMTRIAGE-5236](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5233)

## Testing

`shandy`

### Test description:

Manually verified using the missing command would bring back the default route.

Reset the CFS state when the node had no default route and retriggered CFS. Observed that the default route was added and CFS completed a full configuration of the node.

Logged into UAN over the CAN and compiled an mpi_hello app. I could not run the app as slurm had no nodes available.
```
alanm@uan01:/lus/cls01053/alanm> which cc
/opt/cray/pe/craype/2.7.19/bin/cc
alanm@uan01:/lus/cls01053/alanm> cc -o mpi_hello mpi_hello.c
alanm@uan01:/lus/cls01053/alanm> echo $?
0
```

## Risks and Mitigations

This is adding an ansible task that was missing from the backport. This will now match what is already present in UAN 2.6

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

