### PR TITLE
update ims image filenames to include uan_image_arch

### DIFF
--- a/manifests/iuf-product-manifest.yaml
+++ b/manifests/iuf-product-manifest.yaml
@@ -62,11 +62,11 @@ content:
     images:
     - path: images/application/@uan_image_name@
       rootfs:
-        path: application-@uan_image_version@.squashfs
+        path: application-@uan_image_version@-@uan_image_arch@.squashfs
         md5sum: @uan_rootfs_md5sum@
       kernel:
-        path: @uan_kernel_version@-@uan_image_version@.kernel
+        path: @uan_kernel_version@-@uan_image_version@-@uan_image_arch@.kernel
         md5sum: @uan_kernel_md5sum@
       initrd:
-        path: initrd.img-@uan_image_version@.xz
+        path: initrd.img-@uan_image_version@-@uan_image_arch@.xz
         md5sum: @uan_initrd_md5sum@

--- a/release.sh
+++ b/release.sh
@@ -43,6 +43,7 @@ function copy_manifests {
                s/@patch@/${PATCH}/g
                s/@uan_image_name@/${UAN_IMAGE_NAME}/g
                s/@uan_image_version@/${UAN_IMAGE_VERSION}/g
+               s/@uan_image_arch@/${UAN_IMAGE_ARCH}/g
                s/@uan_kernel_version@/${UAN_KERNEL_VERSION}/g" "${BUILDDIR}/manifests/iuf-product-manifest.yaml" > "${BUILDDIR}/iuf-product-manifest.yaml"
 
     rsync -aq "${ROOTDIR}/docker/" "${BUILDDIR}/docker/"


### PR DESCRIPTION
## Summary and Scope

This PR updates the iuf-product-manifest.yaml to use the new UAN image names which now include an arch value.  No change in the release number.  This will be UAN 2.6.2.

## Issues and Related PRs

* Resolves [CASMUSER-3217](https://jira-pro.it.hpe.com:8443/browse/CASMUSER-3217)

## Testing

### Tested on:

  * `bradi`
 
### Test description:

Installed the UAN 2.6.2 release on bradi using IUF with this change.  It resolved the issue where IUF couldn't find the image files due to the names having the arch value in the name but IUF not looking for that in the name.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

