### PR TITLE
Better default HAProxy configuration

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Better default HAProxy configuration
 - Update versions of k3s, metallb, and haproxy
 - Remove distro rpm repo and replace via ansible
 - Support HA k3s

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.14.1
+UAN_CONFIG_VERSION=1.14.2
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable


### PR DESCRIPTION
## Summary and Scope
If no haproxy config is defined, include all k3s_agent and k3s_server nodes as targets for haproxy/sshd.

## Issues and Related PRs

* Resolves [CASMUSER-3203](https://jira-pro.it.hpe.com:8443/browse/CASMUSER-3203)

## Testing

`tyr`

### Test description:

```
➜  uan git:(CASMUSER-3203-haproxy-nodes) ✗ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 10.103.7.150
Warning: Permanently added '10.103.7.150' (ED25519) to the list of known hosts.
(alanm@10.103.7.150) Password:
Your password will expire in 97 day(s).
Your password will expire in 97 day(s).
Last login: Thu Jul 20 15:57:36 2023 from 10.42.0.4
alanm@uan03:~> exit
logout
Connection to 10.103.7.150 closed.
➜  uan git:(CASMUSER-3203-haproxy-nodes) ✗ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 10.103.7.150
Warning: Permanently added '10.103.7.150' (ED25519) to the list of known hosts.
(alanm@10.103.7.150) Password:
Your password will expire in 97 day(s).
Your password will expire in 97 day(s).
alanm@uan04:~> exit
logout
Connection to 10.103.7.150 closed.
```

```
uan03:~ # kubectl describe -n haproxy-uai cm/haproxy-uai
Name:         haproxy-uai
Namespace:    haproxy-uai
Labels:       app.kubernetes.io/instance=haproxy-uai
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=haproxy
              app.kubernetes.io/version=2.8.1
              helm.sh/chart=haproxy-1.19.2
Annotations:  meta.helm.sh/release-name: haproxy-uai
              meta.helm.sh/release-namespace: haproxy-uai

Data
====
haproxy.cfg:
----

global
  log stdout format raw local0
  maxconn 1024

defaults
  log     global
  mode    tcp
  timeout connect 10s
  timeout client 36h
  timeout server 36h
  option  dontlognull

listen ssh
  bind *:22
  balance leastconn
  mode tcp

  option tcp-check
  tcp-check expect rstring SSH-2.0-OpenSSH.*

  server x3000c0s26b0n0 x3000c0s26b0n0:9001 check inter 10s fall 2 rise 1
  server x3000c0s27b0n0 x3000c0s27b0n0:9001 check inter 10s fall 2 rise 1
  ```

## Risks and Mitigations

No risk whatsoever 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

