### PR TITLE
Add IUF hook to setup HSM groups for k3s

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update versions of k3s, metallb, and haproxy
 - Remove distro rpm repo and replace via ansible
 - Support HA k3s
+- Auto configure HSM groups for k3s support
 
 ## [2.6.2] - 2023-05-30
 - Improvements to the uan_interfaces role for scalability

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ default release distribution and is meant for airgapped system installations.
 1. Wait for the build pipeline to build the package. The build pipeline in this
    repository is tracking changes to tags. Creating the version tag will
    automatically build the release distribution with the version specified.
-1. [Unstable builds](https://arti.dev.cray.com/artifactory/shasta-distribution-unstable-local/uan/)
+1. [Unstable builds](https://artifactory.algol60.net/artifactory/uan/hpe/unstable/)
     are available for download and installation. Any build that is not tagged with
     `v{major}.{minor}.{patch}` (e.g. v1.2.3-RC1) is considered an unstable (dev) build.
-1. [Stable builds](https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/uan/)
+1. [Stable builds](https://artifactory.algol60.net/artifactory/uan/hpe/stable/)
    are available for download and installation as well.
 
 ### Versioning

--- a/install.sh
+++ b/install.sh
@@ -129,3 +129,6 @@ podman run --rm --name uan-$UAN_PRODUCT_VERSION-image-catalog-update \
     -v /etc/kubernetes:/.kube:ro \
     -v ${PWD}:/results:ro \
     registry.local/artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$PRODUCT_CATALOG_UPDATE_VERSION
+
+# Setup K3s node groups in HSM
+iuf_hooks/setup_k3s_groups.sh

--- a/iuf_hooks/setup_k3s_groups.sh
+++ b/iuf_hooks/setup_k3s_groups.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+K3S_SERVER_GROUP="k3s_server"
+K3S_SERVER_GROUP_DESC="K3S server nodes"
+K3S_AGENT_GROUP="k3s_agent"
+K3S_AGENT_GROUP_DESC="K3S agent nodes"
+K3S_EXCLUSIVE_GROUP="K3s"
+NODE_ROLE="Application"
+NODE_SUBROLE="UAN"
+
+function usage() {
+
+  echo "$0 checks to see if the $K3S_SERVER_GROUP and $K3S_AGENT_GROUP groups "
+  echo "exist in HSM and have any members. If they exist and have members, the "
+  echo "script exits and the groups are left as-is. If they don't exist, HSM is "
+  echo "queried for all nodes of $NODE_ROLE $NODE_SUBROLE.  The $K3S_SERVER_GROUP "
+  echo "group is created with the first node as the sole member. "
+  echo "The $K3S_AGENT_GROUP is also created with the remaining nodes as "
+  echo "members."
+  echo ""
+  echo "Usage: $0 [-h | -v]"
+  echo ""
+  echo "options:"
+  echo "h      Print this help"
+  echo "v      verbose mode"
+  echo ""
+  exit 0
+
+}
+
+function check_auth() {
+
+  # Check if a Cray CLI configuration exists...
+  if cray hsm state components list 2>&1 | egrep --silent "Error: No configuration exists"; then
+    echo "ERROR cray command not initialized. Initialize with 'cray init' and try again"
+    exit 1
+  fi
+
+  # Check if Cray CLI has a valid authentication token...
+  if cray hsm state components list > /dev/null 2>&1 | egrep --silent "401|403"; then
+    echo "ERROR cray command not authorized. Authorize with 'cray auth login' and try again"
+    exit 1
+  fi
+
+}
+
+function create_node_group() {
+
+  cray hsm groups create \
+    --members-ids "$1" \
+    --exclusive-group "$2" \
+    --description "$3" \
+    --label "$4"
+
+  if [ $? -ne 0 ]; then
+    echo "ERROR Failed to create $4 HSM group"
+    exit 1
+  fi 
+
+}
+
+function check_node_group() {
+
+  cray hsm groups members list $1 | wc -l | xargs
+
+}
+
+function get_node_xnames() {
+  
+  local LOCAL_NODES
+
+  LOCAL_NODES=$( cray hsm state components list \
+    --role $1 --subrole $2 --format json \
+    | jq -r '.Components[].ID' | sort )
+
+  if [ $? -ne 0 ]; then
+    echo "ERROR Failed to get $1 $2 nodes"
+    exit 1
+  fi
+
+  # Convert newline separated node names into an array
+  IFS=$'\n' read -rd '' -a NODE_ARRAY <<< "$LOCAL_NODES"
+
+}
+
+while getopts "hv" arg; do
+  case $arg in
+    h)
+      usage
+      ;;
+    v)
+      set -x
+      ;;
+  esac
+done
+
+check_auth
+
+# Check if $K3S_SERVER_GROUP and $K3S_AGENT_GROUP HSM groups already exist with members
+NUM_K3S_SERVER_NODES=$( check_node_group $K3S_SERVER_GROUP )
+NUM_K3S_AGENT_NODES=$( check_node_group $K3S_AGENT_GROUP )
+
+if [ $NUM_K3S_SERVER_NODES -ne 0 -a $NUM_K3S_AGENT_NODES -ne 0 ]; then
+  echo "INFO $K3S_SERVER_GROUP and $K3S_AGENT_GROUP are already configured"
+  exit 0
+fi
+
+# Get all the $NODE_ROLE $NODE_SUBROLE nodes, sorted by XNAME (Components.ID)
+get_node_xnames $NODE_ROLE $NODE_SUBROLE 
+# The K3s configuration requires at least one $NODE_ROLE $NODE_SUBROLE nodes
+if [ ${#NODE_ARRAY[@]} -lt 1 ]; then
+  echo "ERROR There are not enough $NODE_ROLE $NODE_SUBROLE nodes to support K3s configuration"
+  exit 1
+fi
+    
+# Set $K3S_SERVER_GROUP to first $NODE_ROLE $NODE_SUBROLE node
+K3S_SERVER=${NODE_ARRAY[0]}
+
+# Create $K3S_SERVER_GROUP HSM group
+create_node_group "$K3S_SERVER" "$K3S_EXCLUSIVE_GROUP" "$K3S_SERVER_GROUP_DESC" "$K3S_SERVER_GROUP"
+
+# Set K3S_AGENT_LIST to remaining $NODE_ROLE $NODE_SUBROLE nodes
+if [ ${#NODE_ARRAY[@]} -gt 1 ]; then
+  # K3S_AGENT_LIST must be comma-separated, so replace so replace space with comma
+  K3S_AGENT_LIST=$( echo ${NODE_ARRAY[@]:1} | sed 's/ /,/g' )
+
+  # Create $K3S_AGENT_GROUP HSM group
+  create_node_group "$K3S_AGENT_LIST" "$K3S_EXCLUSIVE_GROUP" "$K3S_AGENT_GROUP_DESC" "$K3S_AGENT_GROUP"
+fi
+
+exit 0

--- a/manifests/iuf-product-manifest.yaml
+++ b/manifests/iuf-product-manifest.yaml
@@ -29,6 +29,11 @@ description: >
   User Access Nodes (UAN).
 version: @product_version@
 
+hooks:
+  deliver_product:
+    post:
+      script_path: iuf_hooks/setup_k3s_groups.sh
+
 content:
   docker:
   - path: docker

--- a/release.sh
+++ b/release.sh
@@ -136,6 +136,7 @@ EOF
     rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
     rsync -aq "${ROOTDIR}/init-ims-image.sh" "${BUILDDIR}/"
     rsync -aq "${ROOTDIR}/validate-pre-install.sh" "${BUILDDIR}/"
+    rsync -aq "${ROOTDIR}/iuf_hooks/setup_k3s_groups.sh" "${BUILDDIR}/iuf_hooks/setup_k3s_groups.sh"
 }
 
 function package_distribution {
@@ -196,6 +197,7 @@ BUILDDIR="$(realpath -m "$ROOTDIR/dist/${NAME}-${VERSION}")"
 [[ -d "$BUILDDIR" ]] && rm -fr "$BUILDDIR"
 mkdir -p "$BUILDDIR"
 mkdir -p "${BUILDDIR}/lib"
+mkdir -p "${BUILDDIR}/iuf_hooks"
 
 # Create the Release Distribution
 copy_manifests

--- a/vars.sh
+++ b/vars.sh
@@ -69,6 +69,6 @@ THIRD_PARTY_ASSETS=(
     $K3S_INSTALLER/k3s-install.sh
 )
 
-HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc
+HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net:443/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc
 
 BLOBLET_URL="https://artifactory.algol60.net/artifactory/uan-rpms/hpe/stable"


### PR DESCRIPTION
## Summary and Scope

This PR adds an IUF hook script to create and add UANs to the k3s_server and k3s_agent HSM node groups.

Testing in a standalone mode proved to work as expected.  Testing as part of IUF has been performed and worked as expected on tyr. Verification on a single UAN system correctly made just a k3s_server group with that node.

* Resolves [CASMUSER-3238](https://jira-pro.it.hpe.com:8443/browse/CASMUSER-3238)

## Testing

### Tested on:

  * `tyr`
  * `surtur`

### Test description:

Standalone script testing has been performed.  Testing as part of IUF has been performed.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

