### PR TITLE
UAN 2.7.0-beta.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support reading K3s MetalLB IP pool from SLS
 - Update SLE image to SP5
 - Include aarch64 image
+- Consolidate versions in UAN CFS
+- Add evince
+- Add podman configuration changes
+- Misc k3s fixes
 
 ## [2.6.2] - 2023-05-30
 - Improvements to the uan_interfaces role for scalability

--- a/release.sh
+++ b/release.sh
@@ -54,17 +54,17 @@ function extract_and_replace_versions {
         echo "Could not curl $UAN_VCS_VERSIONS_FILE"
         exit 1
     fi
-    METALLB_VERSION=$($YQ '.metallb_version' $UAN_VCS_VERSIONS_FILE)
-    HAPROXY_VERSION=$($YQ '.haproxy_version' $UAN_VCS_VERSIONS_FILE)
-    K3S_VERSION=$($YQ '.k3s_version' $UAN_VCS_VERSIONS_FILE)
-    FRR_VERSION=$($YQ '.frr_version' $UAN_VCS_VERSIONS_FILE)
-    HAPROXY_CONTAINER_VERSION=$($YQ '.haproxy_container_version' $UAN_VCS_VERSIONS_FILE)
+    METALLB_VERSION=$($YQ '.metallb_version' < ${ROOTDIR}/$UAN_VCS_VERSIONS_FILE)
+    HAPROXY_VERSION=$($YQ '.haproxy_version' < ${ROOTDIR}/$UAN_VCS_VERSIONS_FILE)
+    K3S_VERSION=$($YQ '.k3s_version' < ${ROOTDIR}/$UAN_VCS_VERSIONS_FILE)
+    FRR_VERSION=$($YQ '.frr_version' < ${ROOTDIR}/$UAN_VCS_VERSIONS_FILE)
+    HAPROXY_CONTAINER_VERSION=$($YQ '.haproxy_container_version' < ${ROOTDIR}/$UAN_VCS_VERSIONS_FILE)
 
     sed -e "s/@metallb_version@/${METALLB_VERSION}/g
             s/@haproxy_version@/${HAPROXY_VERSION}/g
             s/@k3s_version@/${K3S_VERSION}/g
             s/@frr_version@/${FRR_VERSION}/g
-            s/@haproxy_container_version@/${HAPROXY_CONTAINER_VERSION}/g" "${ROOTDIR}/vars.sh"
+            s/@haproxy_container_version@/${HAPROXY_CONTAINER_VERSION}/g" "${ROOTDIR}/vars.sh" > "${ROOTDIR}/vars_replaced.sh"
 }
 
 function copy_manifests {
@@ -245,7 +245,12 @@ mkdir -p "${BUILDDIR}/iuf_hooks"
 
 # Collect version information from UAN VCS and inject into vars.sh
 extract_and_replace_versions
-source "${ROOTDIR}/vars.sh"
+source "${ROOTDIR}/vars_replaced.sh"
+
+echo "VARS FILE IS HERE"
+cat ${ROOTDIR}/vars_replaced.sh
+
+env
 
 # Create the Release Distribution
 copy_manifests

--- a/release.sh
+++ b/release.sh
@@ -49,7 +49,16 @@ function extract_ansible {
 # Scan the UAN CFS (ansible) for version information. This prevents duplication
 # of version fields and helps decouple the ansible from the release build pipeline
 function extract_versions {
-
+    UAN_VCS_VERSIONS="${BUILDDIR}/vcs/vars/uan_versions.yml"
+    if [[ ! -f ${UAN_VCS_VERSIONS} ]]; then
+        echo "Could not find ${UAN_VCS_VERSIONS}"
+        exit 1
+    fi
+    K3S_VERSION=$(yq '.k3s_version' $UAN_VCS_VERSIONS)
+    METALLB_VERSION=$(yq '.metallb_version' $UAN_VCS_VERSIONS)
+    HAPROXY_VERSION=$(yq '.haproxy_version' $UAN_VCS_VERSIONS)
+    FRR_VERSION=$(yq '.frr_version' $UAN_VCS_VERSIONS)
+    HAPROXY_CONTAINER_VERSION=$(yq '.haproxy_container_version' $UAN_VCS_VERSIONS)
 }
 
 function copy_manifests {

--- a/release.sh
+++ b/release.sh
@@ -247,11 +247,6 @@ mkdir -p "${BUILDDIR}/iuf_hooks"
 extract_and_replace_versions
 source "${ROOTDIR}/vars_replaced.sh"
 
-echo "VARS FILE IS HERE"
-cat ${ROOTDIR}/vars_replaced.sh
-
-env
-
 # Create the Release Distribution
 copy_manifests
 sync_install_content

--- a/release.sh
+++ b/release.sh
@@ -54,11 +54,11 @@ function extract_and_replace_versions {
         echo "Could not curl $UAN_VCS_VERSIONS_FILE"
         exit 1
     fi
-    METALLB_VERSION=$(yq '.metallb_version' $UAN_VCS_VERSIONS_FILE)
-    HAPROXY_VERSION=$(yq '.haproxy_version' $UAN_VCS_VERSIONS_FILE)
-    K3S_VERSION=$(yq '.k3s_version' $UAN_VCS_VERSIONS_FILE)
-    FRR_VERSION=$(yq '.frr_version' $UAN_VCS_VERSIONS_FILE)
-    HAPROXY_CONTAINER_VERSION=$(yq '.haproxy_container_version' $UAN_VCS_VERSIONS_FILE)
+    METALLB_VERSION=$($YQ '.metallb_version' $UAN_VCS_VERSIONS_FILE)
+    HAPROXY_VERSION=$($YQ '.haproxy_version' $UAN_VCS_VERSIONS_FILE)
+    K3S_VERSION=$($YQ '.k3s_version' $UAN_VCS_VERSIONS_FILE)
+    FRR_VERSION=$($YQ '.frr_version' $UAN_VCS_VERSIONS_FILE)
+    HAPROXY_CONTAINER_VERSION=$($YQ '.haproxy_container_version' $UAN_VCS_VERSIONS_FILE)
 
     sed -e "s/@metallb_version@/${METALLB_VERSION}/g
             s/@haproxy_version@/${HAPROXY_VERSION}/g

--- a/vars.sh
+++ b/vars.sh
@@ -31,7 +31,7 @@ MAJOR=`./vendor/semver get major ${VERSION}`
 MINOR=`./vendor/semver get minor ${VERSION}`
 PATCH=`./vendor/semver get patch ${VERSION}`
 
-YQ="artifactory.algol60.net/csm-docker/stable/docker.io/mikefarah/yq:4"
+YQ="docker run -i artifactory.algol60.net/csm-docker/stable/docker.io/mikefarah/yq:4"
 
 # Versions for UAN CFS and Product Catalog Update
 PRODUCT_CATALOG_UPDATE_VERSION="1.3.2"

--- a/vars.sh
+++ b/vars.sh
@@ -31,6 +31,8 @@ MAJOR=`./vendor/semver get major ${VERSION}`
 MINOR=`./vendor/semver get minor ${VERSION}`
 PATCH=`./vendor/semver get patch ${VERSION}`
 
+YQ="artifactory.algol60.net/csm-docker/stable/docker.io/mikefarah/yq:4"
+
 # Versions for UAN CFS and Product Catalog Update
 PRODUCT_CATALOG_UPDATE_VERSION="1.3.2"
 UAN_CONFIG_VERSION='1.14.7'

--- a/vars.sh
+++ b/vars.sh
@@ -45,11 +45,11 @@ UAN_IMAGE_NAME_AARCH64=$UAN_IMAGE_NAME.aarch64-$UAN_IMAGE_VERSION
 UAN_IMAGE_URL=https://artifactory.algol60.net/artifactory/csm-images/$UAN_IMAGE_RELEASE/compute
 
 # Dependencies for UAIs on Application nodes
-K3S_VERSION=1.27.3
-METALLB_VERSION=0.13.10
-HAPROXY_VERSION=1.19.2
-FRR_VERSION=8.4.2
-HAPROXY_CONTAINER_VERSION=2.8.1
+K3S_VERSION=@k3s_version@
+METALLB_VERSION=@metallb_version@
+HAPROXY_VERSION=@haproxy_version@
+FRR_VERSION=@frr_version@
+HAPROXY_CONTAINER_VERSION=@haproxy_container_version@
 K3S_URL=https://github.com/k3s-io/k3s/releases/download/v$K3S_VERSION%2Bk3s1
 K3S_INSTALLER=https://get.k3s.io
 METALLB_URL=https://metallb.github.io/metallb
@@ -74,5 +74,3 @@ THIRD_PARTY_ASSETS=(
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net:443/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc
-
-BLOBLET_URL="https://artifactory.algol60.net/artifactory/uan-rpms/hpe/stable"

--- a/vars.sh
+++ b/vars.sh
@@ -33,7 +33,7 @@ PATCH=`./vendor/semver get patch ${VERSION}`
 
 # Versions for container images and helm charts
 PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.14.4
+UAN_CONFIG_VERSION=1.14.7
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE=stable

--- a/vars.sh
+++ b/vars.sh
@@ -31,46 +31,48 @@ MAJOR=`./vendor/semver get major ${VERSION}`
 MINOR=`./vendor/semver get minor ${VERSION}`
 PATCH=`./vendor/semver get patch ${VERSION}`
 
-# Versions for container images and helm charts
-PRODUCT_CATALOG_UPDATE_VERSION=1.3.2
-UAN_CONFIG_VERSION=1.14.7
+# Versions for UAN CFS and Product Catalog Update
+PRODUCT_CATALOG_UPDATE_VERSION="1.3.2"
+UAN_CONFIG_VERSION='1.14.7'
+UAN_VCS_VERSIONS_FILE='uan_versions.yml'
+UAN_VCS_VERSIONS_URL="https://raw.githubusercontent.com/Cray-HPE/uan/$UAN_CONFIG_VERSION/ansible/vars/$UAN_VCS_VERSIONS_FILE"
 
 # Versions for UAN images
-UAN_IMAGE_RELEASE=stable
-UAN_IMAGE_VERSION=5.2.18
-UAN_KERNEL_VERSION=5.14.21-150500.55.19-default
-UAN_IMAGE_NAME=cray-application-sles15sp5
-UAN_IMAGE_NAME_X86_64=$UAN_IMAGE_NAME.x86_64-$UAN_IMAGE_VERSION
-UAN_IMAGE_NAME_AARCH64=$UAN_IMAGE_NAME.aarch64-$UAN_IMAGE_VERSION
-UAN_IMAGE_URL=https://artifactory.algol60.net/artifactory/csm-images/$UAN_IMAGE_RELEASE/compute
+UAN_IMAGE_RELEASE='stable'
+UAN_IMAGE_VERSION='5.2.18'
+UAN_KERNEL_VERSION='5.14.21-150500.55.19-default'
+UAN_IMAGE_NAME='cray-application-sles15sp5'
+UAN_IMAGE_NAME_X86_64="$UAN_IMAGE_NAME.x86_64-$UAN_IMAGE_VERSION"
+UAN_IMAGE_NAME_AARCH64="$UAN_IMAGE_NAME.aarch64-$UAN_IMAGE_VERSION"
+UAN_IMAGE_URL="https://artifactory.algol60.net/artifactory/csm-images/$UAN_IMAGE_RELEASE/compute"
 
 # Dependencies for UAIs on Application nodes
-K3S_VERSION=@k3s_version@
-METALLB_VERSION=@metallb_version@
-HAPROXY_VERSION=@haproxy_version@
-FRR_VERSION=@frr_version@
-HAPROXY_CONTAINER_VERSION=@haproxy_container_version@
-K3S_URL=https://github.com/k3s-io/k3s/releases/download/v$K3S_VERSION%2Bk3s1
-K3S_INSTALLER=https://get.k3s.io
-METALLB_URL=https://metallb.github.io/metallb
-HAPROXY_URL=https://haproxytech.github.io/helm-charts
+METALLB_VERSION='@metallb_version@'
+HAPROXY_VERSION='@haproxy_version@'
+K3S_VERSION='@k3s_version@'
+FRR_VERSION='@frr_version@'
+HAPROXY_CONTAINER_VERSION='@haproxy_container_version@'
+K3S_URL="https://github.com/k3s-io/k3s/releases/download/v@k3s_version@%2Bk3s1"
+K3S_INSTALLER="https://get.k3s.io"
+METALLB_URL="https://metallb.github.io/metallb"
+HAPROXY_URL="https://haproxytech.github.io/helm-charts"
 
 # Versions for doc product manifest
 DOC_PRODUCT_MANIFEST_VERSION="^0.1.0" # Keep this field like this until further notice
 
 APPLICATION_ASSETS=(
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/compute-$UAN_IMAGE_VERSION-x86_64.squashfs
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION-x86_64.kernel
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/initrd.img-$UAN_IMAGE_VERSION-x86_64.xz
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/compute-$UAN_IMAGE_VERSION-aarch64.squashfs
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION-aarch64.kernel
-    $UAN_IMAGE_URL/$UAN_IMAGE_VERSION/initrd.img-$UAN_IMAGE_VERSION-aarch64.xz
+    "$UAN_IMAGE_URL/$UAN_IMAGE_VERSION/compute-$UAN_IMAGE_VERSION-x86_64.squashfs"
+    "$UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION-x86_64.kernel"
+    "$UAN_IMAGE_URL/$UAN_IMAGE_VERSION/initrd.img-$UAN_IMAGE_VERSION-x86_64.xz"
+    "$UAN_IMAGE_URL/$UAN_IMAGE_VERSION/compute-$UAN_IMAGE_VERSION-aarch64.squashfs"
+    "$UAN_IMAGE_URL/$UAN_IMAGE_VERSION/$UAN_KERNEL_VERSION-$UAN_IMAGE_VERSION-aarch64.kernel"
+    "$UAN_IMAGE_URL/$UAN_IMAGE_VERSION/initrd.img-$UAN_IMAGE_VERSION-aarch64.xz"
 )
 
 THIRD_PARTY_ASSETS=(
-    $K3S_URL/k3s
-    $K3S_URL/k3s-airgap-images-amd64.tar
-    $K3S_INSTALLER/k3s-install.sh
+    "$K3S_URL/k3s"
+    "$K3S_URL/k3s-airgap-images-amd64.tar"
+    "$K3S_INSTALLER/k3s-install.sh"
 )
 
-HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net:443/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc
+HPE_SIGNING_KEY="https://arti.hpc.amslabs.hpecorp.net:443/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc"

--- a/vars.sh
+++ b/vars.sh
@@ -35,13 +35,13 @@ YQ="docker run -i artifactory.algol60.net/csm-docker/stable/docker.io/mikefarah/
 
 # Versions for UAN CFS and Product Catalog Update
 PRODUCT_CATALOG_UPDATE_VERSION="1.3.2"
-UAN_CONFIG_VERSION='1.14.7'
+UAN_CONFIG_VERSION='1.14.8'
 UAN_VCS_VERSIONS_FILE='uan_versions.yml'
 UAN_VCS_VERSIONS_URL="https://raw.githubusercontent.com/Cray-HPE/uan/$UAN_CONFIG_VERSION/ansible/vars/$UAN_VCS_VERSIONS_FILE"
 
 # Versions for UAN images
 UAN_IMAGE_RELEASE='stable'
-UAN_IMAGE_VERSION='5.2.18'
+UAN_IMAGE_VERSION='5.2.26'
 UAN_KERNEL_VERSION='5.14.21-150500.55.19-default'
 UAN_IMAGE_NAME='cray-application-sles15sp5'
 UAN_IMAGE_NAME_X86_64="$UAN_IMAGE_NAME.x86_64-$UAN_IMAGE_VERSION"


### PR DESCRIPTION
## Summary and Scope

UAN 2.7.0-beta.1 
- Support reading K3s MetalLB IP pool from SLS
- Update SLE image to SP5
- Include aarch64 image
- Consolidate versions in UAN CFS
- Add evince
- Add podman configuration changes
- Misc k3s fixes
- Change to "compute" image as the base for application images
- minor fixes for vshasta enablement

## Tested on:

  * `beau`
  * `tyr`

### Test description:

Tested on `beau` and `tyr` by building and booting UANs 

## Risks and Mitigations

Some risk with the number of changes

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

