### PR TITLE
Fix setup_k3s_groups.sh

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2023-11-03
+- Fixes to setup_k3s_groups.sh
+
 ## [2.7.0] - 2023-10-04
 - Better default HAProxy configuration
 - Update versions of k3s, metallb, and haproxy

--- a/iuf_hooks/setup_k3s_groups.sh
+++ b/iuf_hooks/setup_k3s_groups.sh
@@ -23,6 +23,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+# This script expects some commands to return non-zero
+# in the case that node groups do not exist.
+set +e
+
 K3S_SERVER_GROUP="k3s_server"
 K3S_SERVER_GROUP_DESC="K3S server nodes"
 K3S_AGENT_GROUP="k3s_agent"
@@ -84,7 +88,7 @@ function create_node_group() {
 
 function check_node_group() {
 
-  cray hsm groups members list $1 | wc -l | xargs
+  cray hsm groups members list $1 2> /dev/null | wc -l | xargs
 
 }
 
@@ -140,7 +144,9 @@ fi
 K3S_SERVER=${NODE_ARRAY[0]}
 
 # Create $K3S_SERVER_GROUP HSM group
-create_node_group "$K3S_SERVER" "$K3S_EXCLUSIVE_GROUP" "$K3S_SERVER_GROUP_DESC" "$K3S_SERVER_GROUP"
+if [ $NUM_K3S_SERVER_NODES -eq 0 ]; then
+  create_node_group "$K3S_SERVER" "$K3S_EXCLUSIVE_GROUP" "$K3S_SERVER_GROUP_DESC" "$K3S_SERVER_GROUP"
+fi
 
 # Set K3S_AGENT_LIST to remaining $NODE_ROLE $NODE_SUBROLE nodes
 if [ ${#NODE_ARRAY[@]} -gt 1 ]; then


### PR DESCRIPTION
## Summary and Scope

* Make the script quiet during expected failures.
* This script was failing in IUF because of set -e and calls to HSM that are expected to return non-zero so use set +e
* Fix edge case where a sinlge node system would try to recreate k3s_server and fail because k3s_agent didn't exist

## Issues and Related PRs

* Resolves [CASMTRIAGE-6270](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6270)

## Testing

`baldar`

### Test description:

Ran the script in isolation on `tyr`. The script is now quiet, doesn't recreate k3s_server, and uses `set +e` for IUF.

## Risks and Mitigations

No risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

