### PR TITLE
2.7.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Issue a warning in setup_k3s_groups.sh if no UANs are present
 
 ## [2.7.1] - 2023-11-03
 - Fixes to setup_k3s_groups.sh

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.7.2] - 2024-02-29
 - Issue a warning in setup_k3s_groups.sh if no UANs are present
 
 ## [2.7.1] - 2023-11-03

--- a/iuf_hooks/setup_k3s_groups.sh
+++ b/iuf_hooks/setup_k3s_groups.sh
@@ -136,8 +136,8 @@ fi
 get_node_xnames $NODE_ROLE $NODE_SUBROLE 
 # The K3s configuration requires at least one $NODE_ROLE $NODE_SUBROLE nodes
 if [ ${#NODE_ARRAY[@]} -lt 1 ]; then
-  echo "ERROR There are not enough $NODE_ROLE $NODE_SUBROLE nodes to support K3s configuration"
-  exit 1
+  echo "WARNING There are not enough $NODE_ROLE $NODE_SUBROLE nodes to support K3s configuration"
+  exit 0
 fi
     
 # Set $K3S_SERVER_GROUP to first $NODE_ROLE $NODE_SUBROLE node


### PR DESCRIPTION
## Summary and Scope

The IUF hook setup_k3s_groups.sh should not error if there are no UANs detected. Instead, issue a warning and allow the install to complete.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6696](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6696)

## Testing

tyr

### Tested on:

  * `tyr`